### PR TITLE
Added iptables, netstat, and cni configs to networking

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -107,9 +107,17 @@ timeout_done_msg
 if [ -f /etc/docker/daemon.json ]; then
   cat /etc/docker/daemon.json > $TMPDIR/docker/etcdockerdaemon.json
 fi
+
 # Networking
 mkdir -p $TMPDIR/networking
 iptables-save > $TMPDIR/networking/iptablessave 2>&1
+iptables --wait 1 --numeric --verbose --list --table mangle > $TMPDIR/networking/iptablesmangle 2>&1
+iptables --wait 1 --numeric --verbose --list --table nat > $TMPDIR/networking/iptablesnat 2>&1
+iptables --wait 1 --numeric --verbose --list > $TMPDIR/networking/iptables 2>&1
+if $(command -v netstat >/dev/null 2>&1); then
+  netstat --programs --all --numeric --tcp --udp > $TMPDIR/networking/netstat 2>&1
+  netstat --statistics > $TMPDIR/networking/netstatistics 2>&1
+fi
 cat /proc/net/xfrm_stat > $TMPDIR/networking/procnetxfrmstat 2>&1
 if $(command -v ip >/dev/null 2>&1); then
   ip addr show > $TMPDIR/networking/ipaddrshow 2>&1
@@ -118,6 +126,7 @@ fi
 if $(command -v ifconfig >/dev/null 2>&1); then
   ifconfig -a > $TMPDIR/networking/ifconfiga
 fi
+cat /etc/cni/net.d/*.conf* > $TMPDIR/networking/cni-config 2>&1
 
 # System logging
 echo "Collecting systemlogs"

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -115,8 +115,13 @@ iptables --wait 1 --numeric --verbose --list --table mangle > $TMPDIR/networking
 iptables --wait 1 --numeric --verbose --list --table nat > $TMPDIR/networking/iptablesnat 2>&1
 iptables --wait 1 --numeric --verbose --list > $TMPDIR/networking/iptables 2>&1
 if $(command -v netstat >/dev/null 2>&1); then
-  netstat --programs --all --numeric --tcp --udp > $TMPDIR/networking/netstat 2>&1
-  netstat --statistics > $TMPDIR/networking/netstatistics 2>&1
+  if $(grep RancherOS /etc/os-release >/dev/null 2>&1);
+    then
+      netstat -antu > $TMPDIR/networking/netstat 2>&1
+    else
+      netstat --programs --all --numeric --tcp --udp > $TMPDIR/networking/netstat 2>&1
+      netstat --statistics > $TMPDIR/networking/netstatistics 2>&1
+  fi
 fi
 cat /proc/net/xfrm_stat > $TMPDIR/networking/procnetxfrmstat 2>&1
 if $(command -v ip >/dev/null 2>&1); then
@@ -126,7 +131,9 @@ fi
 if $(command -v ifconfig >/dev/null 2>&1); then
   ifconfig -a > $TMPDIR/networking/ifconfiga
 fi
-cat /etc/cni/net.d/*.conf* > $TMPDIR/networking/cni-config 2>&1
+if [ -d /etc/cni/net.d/ ]; then
+  cat /etc/cni/net.d/*.conf* > $TMPDIR/networking/cni-config 2>&1
+fi
 
 # System logging
 echo "Collecting systemlogs"


### PR DESCRIPTION
Additional collection of iptables, netstat and CNI configuration.

Tested on Ubuntu 18.04 and CentOS 7.6

```
../networking# ls -lah
total 296K
drwxr-xr-x 2 root root 4.0K Nov 26 07:03 .
drwx------ 9 root root 4.0K Nov 26 07:03 ..
-rw-r--r-- 1 root root  602 Nov 26 07:03 cni-config
-rw-r--r-- 1 root root  11K Nov 26 07:03 ifconfiga
-rw-r--r-- 1 root root 7.3K Nov 26 07:03 ipaddrshow
-rw-r--r-- 1 root root 1.2K Nov 26 07:03 iproute
-rw-r--r-- 1 root root  96K Nov 26 07:03 iptables
-rw-r--r-- 1 root root 2.8K Nov 26 07:03 iptablesmangle
-rw-r--r-- 1 root root  22K Nov 26 07:03 iptablesnat
-rw-r--r-- 1 root root  90K Nov 26 07:03 iptablessave
-rw-r--r-- 1 root root  36K Nov 26 07:03 netstat
-rw-r--r-- 1 root root 3.6K Nov 26 07:03 netstatistics
-rw-r--r-- 1 root root  756 Nov 26 07:03 procnetxfrmstat
```