### PR TITLE
Additional OS information to the collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Additional collection of OS related information:
- uname
- packages
- services
- lsblk
- cpuinfo
- top
- OS release information
- logs for systemd-based kubelet

Tested on Ubuntu 18.04, CentOS 7.6 and RancherOS 1.5.4.

Included an initial .gitignore file - for discussion on whether we need this.