### PR TITLE
Split into functions, add journald and k3s support

### DIFF
--- a/collection/rancher/v2.x/logs-collector/README.md
+++ b/collection/rancher/v2.x/logs-collector/README.md
@@ -1,6 +1,6 @@
 # logs-collector
 
-The script needs to be downloaded and run directly on the host using the `root` user or using `sudo`.
+The script needs to be downloaded and run directly on the node using the `root` user or using `sudo`.
 
 ## How to use
 
@@ -8,7 +8,18 @@ The script needs to be downloaded and run directly on the host using the `root` 
 * Make sure the script is executable: `chmod +x rancher_logs_collector.sh`
 * Run the script: `./rancher_logs_collector.sh`
 
-## Options
+The script will create a .tar.gz log collection in /tmp by default, all flags are optional.
 
-* `-d directory`: Change output directory (`-d /var/tmp`)
-* `-s time`: Specify Docker logs since parameter (`-s 2h`)
+## Flags
+
+```
+Rancher 2.x log-collector
+  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -f ]
+
+  All flags are optional
+
+  -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
+  -s    Number of days history to collect from container and journald logs (ex: -s 7)
+  -r    Override container runtime if not automatically detected (docker|k3s)
+  -f    Force log collection if the minimum space isn't available
+```

--- a/collection/rancher/v2.x/logs-collector/README.md
+++ b/collection/rancher/v2.x/logs-collector/README.md
@@ -13,7 +13,7 @@ The script will create a .tar.gz log collection in /tmp by default, all flags ar
 ## Flags
 
 ```
-Rancher 2.x log-collector
+Rancher 2.x logs-collector
   Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -f ]
 
   All flags are optional

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -124,7 +124,7 @@ system-all() {
   cat /proc/sys/fs/file-max > $TMPDIR/systeminfo/file-max 2>&1
   ulimit -aH > $TMPDIR/systeminfo/ulimit-hard 2>&1
   uname -a > $TMPDIR/systeminfo/uname 2>&1
-  cp -p /etc/*release > $TMPDIR/systeminfo/osrelease 2>&1
+  cat /etc/*release > $TMPDIR/systeminfo/osrelease 2>&1
   if $(command -v lsblk >/dev/null 2>&1); then
     lsblk > $TMPDIR/systeminfo/lsblk 2>&1
   fi

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -174,7 +174,7 @@ networking() {
   cat /proc/net/xfrm_stat > $TMPDIR/networking/procnetxfrmstat 2>&1
   if $(command -v ip >/dev/null 2>&1); then
     ip addr show > $TMPDIR/networking/ipaddrshow 2>&1
-    ip route sgiw table all > $TMPDIR/networking/iproute 2>&1
+    ip route show table all > $TMPDIR/networking/iproute 2>&1
     ip rule show > $TMPDIR/networking/iprule 2>&1
 
   fi
@@ -269,6 +269,8 @@ docker-rancher() {
   docker exec -it kubelet kubectl get pods -o wide --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/pods 2>&1
   docker exec -it kubelet kubectl get svc -o wide --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/services 2>&1
   docker exec -it kubelet kubectl get endpoints -o wide --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/endpoints 2>&1
+  docker exec -it kubelet kubectl get configmaps --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/configmaps 2>&1
+  docker exec -it kubelet kubectl get namespaces --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/namespaces 2>&1
 
   techo "Collecting nginx-proxy info"
   if docker inspect nginx-proxy >/dev/null 2>&1; then
@@ -291,6 +293,8 @@ k3s-rancher() {
   k3s kubectl get events --all-namespaces > $TMPDIR/k3s/kubectl/events 2>&1
   k3s kubectl get svc -o wide --all-namespaces $TMPDIR/k3s/kubectl/services 2>&1
   k3s kubectl get endpoints -o wide --all-namespaces $TMPDIR/k3s/kubectl/endpoints 2>&1
+  k3s kubectl get configmaps --all-namespaces $TMPDIR/k3s/kubectl/configmaps 2>&1
+  k3s kubectl get namespaces --all-namespaces $TMPDIR/k3s/kubectl/namespaces 2>&1
   techo "Collecting Rancher logs"
   for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
     for SYSTEM_POD in $(k3s kubectl -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
@@ -432,9 +436,9 @@ help() {
 
   All flags are optional
 
-  -d    Output directory for temporary storage and .tgz archive (-d /var/tmp)
-  -s    Number of days history to collect from container and journald logs (-s 7)
-  -r    Set container runtime (docker|k3s)
+  -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
+  -s    Number of days history to collect from container and journald logs (ex: -s 7)
+  -r    Override container runtime if not automatically detected (docker|k3s)
   -f    Force log collection if the minimum space isn't available"
 
 }

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -1,311 +1,528 @@
 #!/bin/bash
+# Rancher log collector for supported Linux distributions
+# https://rancher.com/support-maintenance-terms#rancher-support-matrix
+
+# Included namespaces
+SYSTEM_NAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-logging cattle-pipeline ingress-nginx cattle-prometheus istio-system longhorn-system)
+
+# Included container logs
+KUBE_CONTAINERS=(etcd etcd-rolling-snapshots kube-apiserver kube-controller-manager kubelet kube-scheduler kube-proxy nginx-proxy)
+
+# Included journald logs
+JOURNALD_LOGS=(docker k3s containerd cloud-init systemd-network kubelet kubeproxy)
+
+# Minimum space needed to run the script (MB)
+SPACE=1536
+
+# Set TIMEOUT in seconds for select commands
+TIMEOUT=60
+
+setup() {
+
+  TMPDIR=$(mktemp -d $MKTEMP_BASEDIR)
+  techo "Created ${TMPDIR}"
+
+}
+
+disk-space() {
+
+  AVAILABLE=$(df -m ${TMPDIR} | tail -n 1 | awk '{ print $4 }')
+  if [ "${AVAILABLE}" -lt "${SPACE}" ]
+    then
+      techo "${AVAILABLE} MB space free, minimum needed is ${SPACE} MB."
+      DISK_FULL=1
+  fi
+
+}
+
+sherlock() {
+
+  echo -n "$(timestamp): Detecting OS... "
+  if [ -f /etc/os-release ]
+    then
+      OSRELEASE=$(grep -w ^ID /etc/os-release | cut -d= -f2 | sed 's/"//g')
+      OSVERSION=$(grep -w ^VERSION_ID /etc/os-release | cut -d= -f2 | sed 's/"//g')
+      echo "${OSRELEASE} ${OSVERSION}"
+    else
+      echo -e "\n$(timestamp): couldn't detect OS"
+  fi
+  if [ -n "${RUNTIME_FLAG}" ]
+    then
+      techo "Setting container runtime as ${RUNTIME_FLAG}"
+      RUNTIME="${RUNTIME_FLAG}"
+    else
+      echo -n "$(timestamp): Detecting container runtime... "
+      if $(command -v docker >/dev/null 2>&1)
+        then
+          RUNTIME=docker
+          echo "docker"
+      elif $(command -v k3s >/dev/null 2>&1)
+        then
+          RUNTIME=k3s
+          echo "k3s"
+      else
+        echo -e "\n$(timestamp): couldn't detect container runtime"
+      fi
+  fi
+  echo -n "$(timestamp): Detecting init type... "
+  if $(command -v systemctl >/dev/null 2>&1)
+    then
+      INIT="systemd"
+      echo "systemd"
+    else
+      INIT="other"
+      echo "other"
+  fi
+
+}
+
+system-all() {
+
+  techo "Collecting system info"
+  mkdir -p $TMPDIR/systeminfo
+  hostname > $TMPDIR/systeminfo/hostname 2>&1
+  hostname -f > $TMPDIR/systeminfo/hostnamefqdn 2>&1
+  cp -p /etc/hosts $TMPDIR/systeminfo/etchosts 2>&1
+  cp -p /etc/resolv.conf $TMPDIR/systeminfo/etcresolvconf 2>&1
+  date > $TMPDIR/systeminfo/date 2>&1
+  free -m > $TMPDIR/systeminfo/freem 2>&1
+  uptime > $TMPDIR/systeminfo/uptime 2>&1
+  dmesg -T > $TMPDIR/systeminfo/dmesg 2>&1
+  df -h > $TMPDIR/systeminfo/dfh 2>&1
+  if df -i >/dev/null 2>&1; then
+    df -i > $TMPDIR/systeminfo/dfi 2>&1
+  fi
+  lsmod > $TMPDIR/systeminfo/lsmod 2>&1
+  mount > $TMPDIR/systeminfo/mount 2>&1
+  ps auxfww > $TMPDIR/systeminfo/ps 2>&1
+  vmstat --wide --timestamp 1 5 > $TMPDIR/systeminfo/vmstat 2>&1
+  if [ "${OSRELEASE}" = "rancheros" ]
+    then
+      top -bn 1 > $TMPDIR/systeminfo/top 2>&1
+    else
+      COLUMNS=512 top -cbn 1 > $TMPDIR/systeminfo/top 2>&1
+  fi
+  cat /proc/cpuinfo > $TMPDIR/systeminfo/cpuinfo 2>&1
+  cat /proc/sys/fs/file-nr > $TMPDIR/systeminfo/file-nr 2>&1
+  cat /proc/sys/fs/file-max > $TMPDIR/systeminfo/file-max 2>&1
+  ulimit -aH > $TMPDIR/systeminfo/ulimit-hard 2>&1
+  uname -a > $TMPDIR/systeminfo/uname 2>&1
+  cat /etc/*release > $TMPDIR/systeminfo/osrelease 2>&1
+  if $(command -v lsblk >/dev/null 2>&1); then
+    lsblk > $TMPDIR/systeminfo/lsblk 2>&1
+  fi
+  lsof -Pn > $TMPDIR/systeminfo/lsof 2>&1 & timeout_cmd
+  if $(command -v sysctl >/dev/null 2>&1); then
+    sysctl -a > $TMPDIR/systeminfo/sysctla 2>/dev/null
+  fi
+  if $(command -v systemctl >/dev/null 2>&1); then
+    systemctl list-units > $TMPDIR/systeminfo/systemd-units 2>&1
+  fi
+  if $(command -v service >/dev/null 2>&1); then
+    service --status-all > $TMPDIR/systeminfo/service-statusall 2>&1
+  fi
+
+}
+
+system-ubuntu() {
+
+  if $(command -v ufw >/dev/null 2>&1); then
+    ufw status > $TMPDIR/systeminfo/ubuntu-ufw 2>&1
+  fi
+  if $(command -v apparmor_status >/dev/null 2>&1); then
+    apparmor_status > $TMPDIR/systeminfo/ubuntu-apparmorstatus 2>&1
+  fi
+  if $(command -v dpkg >/dev/null 2>&1); then
+    dpkg -l > $TMPDIR/systeminfo/packages-dpkg 2>&1
+  fi
+
+}
+
+system-rhel() {
+
+  systemctl status NetworkManager > $TMPDIR/systeminfo/rhel-statusnetworkmanager 2>&1
+  systemctl status firewalld > $TMPDIR/systeminfo/rhel-statusfirewalld 2>&1
+  if $(command -v getenforce >/dev/null 2>&1); then
+    getenforce > $TMPDIR/systeminfo/rhel-getenforce 2>&1
+  fi
+  if $(command -v rpm >/dev/null 2>&1); then
+    rpm -qa > $TMPDIR/systeminfo/packages-rpm 2>&1
+  fi
+
+}
+
+networking() {
+
+  techo "Collecting network output"
+  mkdir -p $TMPDIR/networking
+  iptables-save > $TMPDIR/networking/iptablessave 2>&1
+  iptables --wait 1 --numeric --verbose --list --table mangle > $TMPDIR/networking/iptablesmangle 2>&1
+  iptables --wait 1 --numeric --verbose --list --table nat > $TMPDIR/networking/iptablesnat 2>&1
+  iptables --wait 1 --numeric --verbose --list > $TMPDIR/networking/iptables 2>&1
+  if $(command -v netstat >/dev/null 2>&1); then
+    if [ "${OSRELEASE}" = "rancheros" ]
+      then
+        netstat -antu > $TMPDIR/networking/netstat 2>&1
+      else
+        netstat --programs --all --numeric --tcp --udp > $TMPDIR/networking/netstat 2>&1
+        netstat --statistics > $TMPDIR/networking/netstatistics 2>&1
+    fi
+  fi
+  if $(command -v ipvsadm >/dev/null 2>&1); then
+    ipvsadm -ln > $TMPDIR/networking/ipvsadm 2>&1
+  fi
+  cat /proc/net/xfrm_stat > $TMPDIR/networking/procnetxfrmstat 2>&1
+  if $(command -v ip >/dev/null 2>&1); then
+    ip addr show > $TMPDIR/networking/ipaddrshow 2>&1
+    ip route sgiw table all > $TMPDIR/networking/iproute 2>&1
+    ip rule show > $TMPDIR/networking/iprule 2>&1
+
+  fi
+  if $(command -v ifconfig >/dev/null 2>&1); then
+    ifconfig -a > $TMPDIR/networking/ifconfiga
+  fi
+  if [ -d /etc/cni/net.d/ ]; then
+    mkdir -p $TMPDIR/networking/cni
+    cp -r /etc/cni/net.d/* $TMPDIR/networking/cni 2>&1
+  fi
+
+}
+
+docker-logs() {
+
+  techo "Collecting Docker info"
+  mkdir -p $TMPDIR/docker
+
+  docker info > $TMPDIR/docker/dockerinfo 2>&1 & timeout_cmd
+  docker ps -a > $TMPDIR/docker/dockerpsa 2>&1
+  docker stats -a --no-stream > $TMPDIR/docker/dockerstats 2>&1 & timeout_cmd
+  docker images > $TMPDIR/docker/dockerstats 2>&1 & timeout_cmd
+
+  if [ -f /etc/docker/daemon.json ]; then
+    cat /etc/docker/daemon.json > $TMPDIR/docker/etcdockerdaemon.json
+  fi
+
+}
+
+k3s-logs() {
+
+  techo "Collecting k3s info"
+  mkdir -p $TMPDIR/k3s/crictl
+  k3s check-config > $TMPDIR/k3s/check-config 2>&1
+  k3s crictl ps -a > $TMPDIR/k3s/crictl/psa 2>&1
+  k3s crictl pods > $TMPDIR/k3s/crictl/pods 2>&1
+  k3s crictl info > $TMPDIR/k3s/crictl/info 2>&1
+  k3s crictl stats -a > $TMPDIR/k3s/crictl/statsa 2>&1
+  k3s crictl version > $TMPDIR/k3s/crictl/version 2>&1
+  k3s crictl images > $TMPDIR/k3s/crictl/images 2>&1
+  k3s crictl imagefsinfo > $TMPDIR/k3s/crictl/imagefsinfo 2>&1
+
+}
+
+docker-rancher() {
+
+  techo "Collecting Rancher logs"
+  # Discover any server or agent running
+  mkdir -p $TMPDIR/rancher/containerinspect
+  mkdir -p $TMPDIR/rancher/containerlogs
+  RANCHERSERVERS=$(docker ps -a | grep -E "rancher/rancher:|rancher/rancher " | awk '{ print $1 }')
+  RANCHERAGENTS=$(docker ps -a | grep -E "rancher/rancher-agent:|rancher/rancher-agent " | awk '{ print $1 }')
+
+  for RANCHERSERVER in $RANCHERSERVERS; do
+    docker inspect $RANCHERSERVER > $TMPDIR/rancher/containerinspect/server-$RANCHERSERVER 2>&1
+    docker logs $SINCE_FLAG -t $RANCHERSERVER > $TMPDIR/rancher/containerlogs/server-$RANCHERSERVER 2>&1
+  done
+
+  for RANCHERAGENT in $RANCHERAGENTS; do
+    docker inspect $RANCHERAGENT > $TMPDIR/rancher/containerinspect/agent-$RANCHERAGENT 2>&1
+    docker logs $SINCE_FLAG -t $RANCHERAGENT > $TMPDIR/rancher/containerlogs/agent-$RANCHERAGENT 2>&1
+  done
+
+  # K8s Docker container logging
+  techo "Collecting k8s component logs"
+  mkdir -p $TMPDIR/k8s/containerlogs
+  mkdir -p $TMPDIR/k8s/containerinspect
+  for KUBE_CONTAINER in "${KUBE_CONTAINERS[@]}"; do
+    if [ "$(docker ps -a -q -f name=$KUBE_CONTAINER)" ]; then
+            docker inspect $KUBE_CONTAINER > $TMPDIR/k8s/containerinspect/$KUBE_CONTAINER 2>&1
+      docker logs $SINCE_FLAG -t $KUBE_CONTAINER > $TMPDIR/k8s/containerlogs/$KUBE_CONTAINER 2>&1
+    fi
+  done
+
+  # System pods
+  techo "Collecting system pod logs"
+  mkdir -p $TMPDIR/k8s/podlogs
+  mkdir -p $TMPDIR/k8s/podinspect
+  for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
+    CONTAINERS=$(docker ps -a --filter name=$SYSTEM_NAMESPACE --format "{{.Names}}")
+    for CONTAINER in $CONTAINERS; do
+      docker inspect $CONTAINER > $TMPDIR/k8s/podinspect/$CONTAINER 2>&1
+      docker logs $SINCE_FLAG -t $CONTAINER > $TMPDIR/k8s/podlogs/$CONTAINER 2>&1
+    done
+  done
+
+  # Node and pod overview
+  mkdir -p $TMPDIR/k8s/kubectl
+  KUBECONFIG=/etc/kubernetes/ssl/kubecfg-kube-node.yaml
+  docker exec -it kubelet kubectl get nodes -o wide --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/nodes 2>&1
+  docker exec -it kubelet kubectl describe nodes --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/nodesdescribe 2>&1
+  docker exec -it kubelet kubectl get pods -o wide --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/pods 2>&1
+  docker exec -it kubelet kubectl get svc -o wide --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/services 2>&1
+  docker exec -it kubelet kubectl get endpoints -o wide --all-namespaces --kubeconfig=$KUBECONFIG > $TMPDIR/k8s/kubectl/endpoints 2>&1
+
+  techo "Collecting nginx-proxy info"
+  if docker inspect nginx-proxy >/dev/null 2>&1; then
+    mkdir -p $TMPDIR/k8s/nginx-proxy
+    docker exec nginx-proxy cat /etc/nginx/nginx.conf > $TMPDIR/k8s/nginx-proxy/nginx.conf 2>&1
+  fi
+
+}
+
+k3s-rancher() {
+
+  techo "Collecting k3s logs"
+  mkdir -p $TMPDIR/k3s/logs
+  mkdir -p $TMPDIR/k3s/podlogs
+  mkdir -p $TMPDIR/k3s/kubectl
+  k3s kubectl get nodes -o yaml > $TMPDIR/k3s/kubectl/nodes 2>&1
+  k3s kubectl describe nodes > $TMPDIR/k3s/kubectl/nodesdescribe 2>&1
+  k3s kubectl version > $TMPDIR/k3s/kubectl/version 2>&1
+  k3s kubectl get pods -o wide --all-namespaces > $TMPDIR/k3s/kubectl/pods 2>&1
+  k3s kubectl get events --all-namespaces > $TMPDIR/k3s/kubectl/events 2>&1
+  k3s kubectl get svc -o wide --all-namespaces $TMPDIR/k3s/kubectl/services 2>&1
+  k3s kubectl get endpoints -o wide --all-namespaces $TMPDIR/k3s/kubectl/endpoints 2>&1
+  techo "Collecting Rancher logs"
+  for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
+    for SYSTEM_POD in $(k3s kubectl -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
+      k3s kubectl -n $SYSTEM_NAMESPACE logs $SYSTEM_POD > $TMPDIR/k3s/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD 2>&1
+    done
+  done
+
+}
+
+var-log() {
+
+  techo "Collecting system logs from /var/log"
+  mkdir -p $TMPDIR/systemlogs
+  cp /var/log/syslog* /var/log/messages* /var/log/kern* /var/log/docker* /var/log/system-docker* /var/log/cloud-init* /var/log/audit/* $TMPDIR/systemlogs 2>/dev/null
+
+}
+
+journald-log() {
+
+  techo "Collecting system logs from journald"
+  mkdir -p $TMPDIR/journald
+  for JOURNALD_LOG in "${JOURNALD_LOGS[@]}"; do
+    if "$(grep $JOURNALD_LOG $TMPDIR/systeminfo/systemd-units > /dev/null 2>&1)"; then
+      journalctl $SINCE_FLAG --unit=$JOURNALD_LOG > $TMPDIR/journald/$JOURNALD_LOG
+    fi
+  done
+
+}
+
+certs() {
+
+  # K8s directory state
+  techo "Collecting k8s directory state"
+  mkdir -p $TMPDIR/k8s/directories
+  if [ -d /opt/rke/etc/kubernetes/ssl ]; then
+    find /opt/rke/etc/kubernetes/ssl -type f -exec ls -la {} \; > $TMPDIR/k8s/directories/findoptrkeetckubernetesssl 2>&1
+  elif [ -d /etc/kubernetes/ssl ]; then
+    find /etc/kubernetes/ssl -type f -exec ls -la {} \; > $TMPDIR/k8s/directories/findetckubernetesssl 2>&1
+  fi
+
+  techo "Collecting k8s certificates"
+  mkdir -p $TMPDIR/k8s/certs
+  if [ -d /opt/rke/etc/kubernetes/ssl ]; then
+    CERTS=$(find /opt/rke/etc/kubernetes/ssl -type f -name *.pem | grep -v "\-key\.pem$")
+    for CERT in $CERTS; do
+      openssl x509 -in $CERT -text -noout > $TMPDIR/k8s/certs/$(basename $CERT) 2>&1
+    done
+    if [ -d /opt/rke/etc/kubernetes/.tmp ]; then
+      mkdir -p $TMPDIR/k8s/tmpcerts
+      TMPCERTS=$(find /opt/rke/etc/kubernetes/.tmp -type f -name *.pem | grep -v "\-key\.pem$")
+      for TMPCERT in $TMPCERTS; do
+        openssl x509 -in $TMPCERT -text -noout > $TMPDIR/k8s/tmpcerts/$(basename $TMPCERT) 2>&1
+      done
+    fi
+  elif [ -d /etc/kubernetes/ssl ]; then
+    CERTS=$(find /etc/kubernetes/ssl -type f -name *.pem | grep -v "\-key\.pem$")
+    for CERT in $CERTS; do
+      openssl x509 -in $CERT -text -noout > $TMPDIR/k8s/certs/$(basename $CERT) 2>&1
+    done
+    if [ -d /etc/kubernetes/.tmp ]; then
+      mkdir -p $TMPDIR/k8s/tmpcerts
+      TMPCERTS=$(find /etc/kubernetes/.tmp -type f -name *.pem | grep -v "\-key\.pem$")
+      for TMPCERT in $TMPCERTS; do
+        openssl x509 -in $TMPCERT -text -noout > $TMPDIR/k8s/tmpcerts/$(basename $TMPCERT) 2>&1
+      done
+    fi
+  fi
+
+}
+
+etcd() {
+
+  techo "Collecting etcd info"
+  mkdir -p $TMPDIR/etcd
+  if [ -d /var/lib/etcd ]; then
+    find /var/lib/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findvarlibetcd 2>&1
+  elif [ -d /opt/rke/var/lib/etcd ]; then
+    find /opt/rke/var/lib/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkevarlibetcd 2>&1
+  fi
+
+  # /opt/rke contents
+  if [ -d /opt/rke/etcd-snapshots ]; then
+    find /opt/rke/etcd-snapshots -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkeetcdsnaphots 2>&1
+  fi
+
+  if docker ps --format='{{.Names}}' | grep -q ^etcd$ >/dev/null 2>&1; then
+    techo "Collecting etcdctl output"
+    PARAM=""
+    # Check for older versions with incorrectly set ETCDCTL_ENDPOINT vs the correct ETCDCTL_ENDPOINTS
+    # If ETCDCTL_ENDPOINTS is empty, its an older version
+    if [ -z $(docker exec etcd printenv ETCDCTL_ENDPOINTS) ]; then
+      ENDPOINT=$(docker exec etcd printenv ETCDCTL_ENDPOINT)
+      if echo $ENDPOINT | grep -vq 0.0.0.0; then
+        PARAM="--endpoints=$(docker exec etcd printenv ETCDCTL_ENDPOINT)"
+      fi
+    fi
+    docker exec etcd sh -c "etcdctl $PARAM member list"  > $TMPDIR/etcd/memberlist 2>&1
+    docker exec etcd etcdctl endpoint status --endpoints=$(docker exec etcd /bin/sh -c "etcdctl $PARAM member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','") --write-out table > $TMPDIR/etcd/endpointstatus 2>&1
+    docker exec etcd etcdctl endpoint health --endpoints=$(docker exec etcd /bin/sh -c "etcdctl $PARAM member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','") > $TMPDIR/etcd/endpointhealth 2>&1
+    docker exec etcd sh -c "etcdctl $PARAM alarm list" > $TMPDIR/etcd/alarmlist 2>&1
+  fi
+
+}
+
+timeout_cmd() {
+
+  TIMEOUT_EXCEEDED_MSG="$1 command timed out, killing process to prevent hanging."
+  WPID=$!
+  sleep $TIMEOUT && if kill -0 $WPID > /dev/null 2>&1
+    then
+      echo "$1 command timed out, killing process to prevent hanging."; kill $WPID &> /dev/null;
+  fi & KPID=$!; wait $WPID
+
+}
+
+archive() {
+
+  FILEDIR=$(dirname $TMPDIR)
+  FILENAME="$(hostname)-$(date +'%Y-%m-%d_%H_%M_%S').tar"
+  tar --create --file ${FILEDIR}/${FILENAME} --directory ${TMPDIR}/ .
+  ## gzip separately for Rancher OS
+  gzip ${FILEDIR}/${FILENAME}
+
+  techo "Created ${FILEDIR}/${FILENAME}.gz"
+
+}
+
+cleanup() {
+
+  techo "Removing ${TMPDIR}"
+  rm --recursive --force "${TMPDIR}" >/dev/null 2>&1
+
+}
+
+help() {
+
+  echo "Rancher 2.x log-collector
+  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -f ]
+
+  All flags are optional
+
+  -d    Output directory for temporary storage and .tgz archive (-d /var/tmp)
+  -s    Number of days history to collect from container and journald logs (-s 7)
+  -r    Set container runtime (docker|k3s)
+  -f    Force log collection if the minimum space isn't available"
+
+}
+
+timestamp() {
+
+  date "+%Y-%m-%d %H:%M:%S"
+
+}
+
+techo() {
+
+  echo "$(timestamp): $*"
+
+}
 
 # Check if we're running as root.
-if [[ $EUID -ne 0 ]]; then
-  echo "This script must be run as root"
-  exit 1
+if [[ $EUID -ne 0 ]]
+  then
+    techo "This script must be run as root"
+    exit 1
 fi
 
-MKTEMP_BASEDIR=""
-DOCKER_LOGOPTS=""
-
-while getopts ":d:s:" opt; do
+while getopts ":d:s:r:fh" opt; do
   case $opt in
     d)
       MKTEMP_BASEDIR="-p ${OPTARG}"
       ;;
     s)
-      DOCKER_LOGOPTS="--since ${OPTARG}"
+      START=$(date -d "-${OPTARG} days" '+%Y-%m-%d')
+      SINCE_FLAG="--since ${START}"
       ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
+    r)
+      RUNTIME_FLAG="${OPTARG}"
+      ;;
+    f)
+      FORCE=1
+      ;;
+    h)
+      help && exit 0
       ;;
     :)
-      echo "Option -$OPTARG requires an argument." >&2
+      techo "Option -$OPTARG requires an argument."
       exit 1
       ;;
+    *)
+      help && exit 0
   esac
 done
 
-# Create temp directory
-TMPDIR=$(mktemp -d $MKTEMP_BASEDIR)
-
-# Set TIMEOUT in seconds for select commands
-TIMEOUT=60
-
-# Detect RancherOS
-if $(grep RancherOS /etc/os-release >/dev/null 2>&1); then
-  RANCHEROS=true
-fi
-
-function timeout_start_msg() {
-  TIMEOUT_CMD=$1
-  TIMEOUT_EXCEEDED_MSG="$TIMEOUT_CMD command timed out, killing process to prevent hanging."
-  echo "Executing $TIMEOUT_CMD with a timeout of $TIMEOUT seconds."
-}
-function timeout_done_msg() {
-  echo "Execution of $TIMEOUT_CMD has finished."
-  echo
-}
-function timeout_cmd() {
-  WPID=$!; sleep $TIMEOUT && if kill -0 $WPID > /dev/null 2>&1; then echo $TIMEOUT_EXCEEDED_MSG; kill $WPID &> /dev/null; fi & KPID=$!; wait $WPID
-}
-
-# System info
-echo "Collecting systeminfo"
-mkdir -p $TMPDIR/systeminfo
-hostname > $TMPDIR/systeminfo/hostname 2>&1
-hostname -f > $TMPDIR/systeminfo/hostnamefqdn 2>&1
-cp -p /etc/hosts $TMPDIR/systeminfo/etchosts 2>&1
-cp -p /etc/resolv.conf $TMPDIR/systeminfo/etcresolvconf 2>&1
-date > $TMPDIR/systeminfo/date 2>&1
-free -m > $TMPDIR/systeminfo/freem 2>&1
-uptime > $TMPDIR/systeminfo/uptime 2>&1
-dmesg -T > $TMPDIR/systeminfo/dmesg 2>&1
-df -h > $TMPDIR/systeminfo/dfh 2>&1
-if df -i >/dev/null 2>&1; then
-  df -i > $TMPDIR/systeminfo/dfi 2>&1
-fi
-lsmod > $TMPDIR/systeminfo/lsmod 2>&1
-mount > $TMPDIR/systeminfo/mount 2>&1
-ps auxfww > $TMPDIR/systeminfo/ps 2>&1
-if [ "${RANCHEROS}" = true ]
+setup
+disk-space
+if [ -n "${DISK_FULL}" ]
   then
-    top -bn 1 > $TMPDIR/systeminfo/top 2>&1
-  else
-    COLUMNS=512 top -cbn 1 > $TMPDIR/systeminfo/top 2>&1
-fi
-cat /proc/cpuinfo > $TMPDIR/systeminfo/cpuinfo 2>&1
-uname -a > $TMPDIR/systeminfo/uname 2>&1
-cat /etc/*release > $TMPDIR/systeminfo/osrelease 2>&1
-if $(command -v lsblk >/dev/null 2>&1); then
-  lsblk > $TMPDIR/systeminfo/lsblk 2>&1
-fi
-
-timeout_start_msg "lsof"
-lsof -Pn > $TMPDIR/systeminfo/lsof 2>&1 & timeout_cmd
-timeout_done_msg
-
-if $(command -v sysctl >/dev/null 2>&1); then
-  sysctl -a > $TMPDIR/systeminfo/sysctla 2>/dev/null
-fi
-if $(command -v systemctl >/dev/null 2>&1); then
-  systemctl list-units > $TMPDIR/systeminfo/systemd-units 2>&1
-fi
-if $(command -v service >/dev/null 2>&1); then
-  service --status-all > $TMPDIR/systeminfo/service-statusall 2>&1
-fi
-
-# OS: Ubuntu
-if $(command -v ufw >/dev/null 2>&1); then
-  ufw status > $TMPDIR/systeminfo/ubuntu-ufw 2>&1
-fi
-if $(command -v apparmor_status >/dev/null 2>&1); then
-  apparmor_status > $TMPDIR/systeminfo/ubuntu-apparmorstatus 2>&1
-fi
-if $(command -v dpkg >/dev/null 2>&1); then
-  dpkg -l > $TMPDIR/systeminfo/packages-dpkg 2>&1
-fi
-
-# OS: RHEL
-if [ -f /etc/redhat-release ]; then
-  systemctl status NetworkManager > $TMPDIR/systeminfo/rhel-statusnetworkmanager 2>&1
-  systemctl status firewalld > $TMPDIR/systeminfo/rhel-statusfirewalld 2>&1
-  if $(command -v getenforce >/dev/null 2>&1); then
-  getenforce > $TMPDIR/systeminfo/rhel-getenforce 2>&1
-  fi
-fi
-if $(command -v rpm >/dev/null 2>&1); then
-  rpm -qa > $TMPDIR/systeminfo/packages-rpm 2>&1
-fi
-
-# Docker
-echo "Collecting Docker info"
-mkdir -p $TMPDIR/docker
-
-timeout_start_msg "docker info"
-docker info >$TMPDIR/docker/dockerinfo 2>&1 & timeout_cmd
-timeout_done_msg
-
-timeout_start_msg "docker ps -a"
-docker ps -a >$TMPDIR/docker/dockerpsa 2>&1
-timeout_done_msg
-
-timeout_start_msg "docker stats"
-docker stats -a --no-stream >$TMPDIR/docker/dockerstats 2>&1 & timeout_cmd
-timeout_done_msg
-
-if [ -f /etc/docker/daemon.json ]; then
-  cat /etc/docker/daemon.json > $TMPDIR/docker/etcdockerdaemon.json
-fi
-
-# Networking
-mkdir -p $TMPDIR/networking
-iptables-save > $TMPDIR/networking/iptablessave 2>&1
-iptables --wait 1 --numeric --verbose --list --table mangle > $TMPDIR/networking/iptablesmangle 2>&1
-iptables --wait 1 --numeric --verbose --list --table nat > $TMPDIR/networking/iptablesnat 2>&1
-iptables --wait 1 --numeric --verbose --list > $TMPDIR/networking/iptables 2>&1
-if $(command -v netstat >/dev/null 2>&1); then
-  if [ "${RANCHEROS}" = true ]
-    then
-      netstat -antu > $TMPDIR/networking/netstat 2>&1
-    else
-      netstat --programs --all --numeric --tcp --udp > $TMPDIR/networking/netstat 2>&1
-      netstat --statistics > $TMPDIR/networking/netstatistics 2>&1
-  fi
-fi
-cat /proc/net/xfrm_stat > $TMPDIR/networking/procnetxfrmstat 2>&1
-if $(command -v ip >/dev/null 2>&1); then
-  ip addr show > $TMPDIR/networking/ipaddrshow 2>&1
-  ip route > $TMPDIR/networking/iproute 2>&1
-fi
-if $(command -v ifconfig >/dev/null 2>&1); then
-  ifconfig -a > $TMPDIR/networking/ifconfiga
-fi
-if [ -d /etc/cni/net.d/ ]; then
-  cat /etc/cni/net.d/*.conf* > $TMPDIR/networking/cni-config 2>&1
-fi
-
-# System logging
-echo "Collecting systemlogs"
-mkdir -p $TMPDIR/systemlogs
-cp /var/log/syslog* /var/log/messages* /var/log/kern* /var/log/docker* /var/log/system-docker* /var/log/audit/* $TMPDIR/systemlogs 2>/dev/null
-
-# Rancher logging
-echo "Collecting Rancher logs"
-# Discover any server or agent running
-mkdir -p $TMPDIR/rancher/containerinspect
-mkdir -p $TMPDIR/rancher/containerlogs
-RANCHERSERVERS=$(docker ps -a | grep -E "rancher/rancher:|rancher/rancher " | awk '{ print $1 }')
-RANCHERAGENTS=$(docker ps -a | grep -E "rancher/rancher-agent:|rancher/rancher-agent " | awk '{ print $1 }')
-
-for RANCHERSERVER in $RANCHERSERVERS; do
-  docker inspect $RANCHERSERVER > $TMPDIR/rancher/containerinspect/server-$RANCHERSERVER 2>&1
-  docker logs $DOCKER_LOGOPTS -t $RANCHERSERVER > $TMPDIR/rancher/containerlogs/server-$RANCHERSERVER 2>&1
-done
-
-for RANCHERAGENT in $RANCHERAGENTS; do
-  docker inspect $RANCHERAGENT > $TMPDIR/rancher/containerinspect/agent-$RANCHERAGENT 2>&1
-  docker logs $DOCKER_LOGOPTS -t $RANCHERAGENT > $TMPDIR/rancher/containerlogs/agent-$RANCHERAGENT 2>&1
-done
-
-# K8s Docker container logging
-echo "Collecting k8s container logging"
-mkdir -p $TMPDIR/k8s/containerlogs
-mkdir -p $TMPDIR/k8s/containerinspect
-KUBECONTAINERS=(etcd etcd-rolling-snapshots kube-apiserver kube-controller-manager kubelet kube-scheduler kube-proxy nginx-proxy)
-for KUBECONTAINER in "${KUBECONTAINERS[@]}"; do
-  if [ "$(docker ps -a -q -f name=$KUBECONTAINER)" ]; then
-          docker inspect $KUBECONTAINER > $TMPDIR/k8s/containerinspect/$KUBECONTAINER 2>&1
-	  docker logs $DOCKER_LOGOPTS -t $KUBECONTAINER > $TMPDIR/k8s/containerlogs/$KUBECONTAINER 2>&1
-  fi
-done
-if $(grep "kubelet.service" $TMPDIR/systeminfo/systemd-units > /dev/null 2>&1); then
-  journalctl --unit=kubelet > $TMPDIR/k8s/containerlogs/journalctl-kubelet
-  journalctl --unit=kubeproxy > $TMPDIR/k8s/containerlogs/journalctl-kubeproxy
-fi
-
-# System pods
-echo "Collecting system pods logging"
-mkdir -p $TMPDIR/k8s/podlogs
-mkdir -p $TMPDIR/k8s/podinspect
-SYSTEMNAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-logging cattle-pipeline ingress-nginx cattle-prometheus istio-system)
-for SYSTEMNAMESPACE in "${SYSTEMNAMESPACES[@]}"; do
-  CONTAINERS=$(docker ps -a --filter name=$SYSTEMNAMESPACE --format "{{.Names}}")
-  for CONTAINER in $CONTAINERS; do
-    docker inspect $CONTAINER > $TMPDIR/k8s/podinspect/$CONTAINER 2>&1
-    docker logs $DOCKER_LOGOPTS -t $CONTAINER > $TMPDIR/k8s/podlogs/$CONTAINER 2>&1
-  done
-done
-
-# K8s directory state
-echo "Collecting k8s directory state"
-mkdir -p $TMPDIR/k8s/directories
-if [ -d /opt/rke/etc/kubernetes/ssl ]; then
-  find /opt/rke/etc/kubernetes/ssl -type f -exec ls -la {} \; > $TMPDIR/k8s/directories/findoptrkeetckubernetesssl 2>&1
-elif [ -d /etc/kubernetes/ssl ]; then
-  find /etc/kubernetes/ssl -type f -exec ls -la {} \; > $TMPDIR/k8s/directories/findetckubernetesssl 2>&1
-fi
-
-# K8s certs
-echo "Collecting k8s certificates"
-mkdir -p $TMPDIR/k8s/certs
-if [ -d /opt/rke/etc/kubernetes/ssl ]; then
-  CERTS=$(find /opt/rke/etc/kubernetes/ssl -type f -name *.pem | grep -v "\-key\.pem$")
-  for CERT in $CERTS; do
-    openssl x509 -in $CERT -text -noout > $TMPDIR/k8s/certs/$(basename $CERT) 2>&1
-  done
-  if [ -d /opt/rke/etc/kubernetes/.tmp ]; then
-    mkdir -p $TMPDIR/k8s/tmpcerts
-    TMPCERTS=$(find /opt/rke/etc/kubernetes/.tmp -type f -name *.pem | grep -v "\-key\.pem$")
-    for TMPCERT in $TMPCERTS; do
-      openssl x509 -in $TMPCERT -text -noout > $TMPDIR/k8s/tmpcerts/$(basename $TMPCERT) 2>&1
-    done
-  fi
-elif [ -d /etc/kubernetes/ssl ]; then
-  CERTS=$(find /etc/kubernetes/ssl -type f -name *.pem | grep -v "\-key\.pem$")
-  for CERT in $CERTS; do
-    openssl x509 -in $CERT -text -noout > $TMPDIR/k8s/certs/$(basename $CERT) 2>&1
-  done
-  if [ -d /etc/kubernetes/.tmp ]; then
-    mkdir -p $TMPDIR/k8s/tmpcerts
-    TMPCERTS=$(find /etc/kubernetes/.tmp -type f -name *.pem | grep -v "\-key\.pem$")
-    for TMPCERT in $TMPCERTS; do
-      openssl x509 -in $TMPCERT -text -noout > $TMPDIR/k8s/tmpcerts/$(basename $TMPCERT) 2>&1
-    done
-  fi
-fi
-
-# etcd
-echo "Collecting etcd info"
-mkdir -p $TMPDIR/etcd
-# /var/lib/etcd contents
-if [ -d /var/lib/etcd ]; then
-  find /var/lib/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findvarlibetcd 2>&1
-elif [ -d /opt/rke/var/lib/etcd ]; then
-  find /opt/rke/var/lib/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkevarlibetcd 2>&1
-fi
-
-# /opt/rke contents
-if [ -d /opt/rke/etcd-snapshots ]; then
-  find /opt/rke/etcd-snapshots -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkeetcdsnaphots 2>&1
-fi
-
-# etcd
-if docker ps --format='{{.Names}}' | grep -q ^etcd$ >/dev/null 2>&1; then
-  echo "Collecting etcdctl output"
-  PARAM=""
-  # Check for older versions with incorrectly set ETCDCTL_ENDPOINT vs the correct ETCDCTL_ENDPOINTS
-  # If ETCDCTL_ENDPOINTS is empty, its an older version
-  if [ -z $(docker exec etcd printenv ETCDCTL_ENDPOINTS) ]; then
-    ENDPOINT=$(docker exec etcd printenv ETCDCTL_ENDPOINT)
-    if echo $ENDPOINT | grep -vq 0.0.0.0; then
-      PARAM="--endpoints=$(docker exec etcd printenv ETCDCTL_ENDPOINT)"
+    if [ -z "${FORCE}" ]
+      then
+        techo "Cleaning up and exiting"
+        cleanup
+        exit 1
+      else
+        techo "-f (force) used, continuing"
     fi
-  fi
-  docker exec etcd sh -c "etcdctl $PARAM member list"  > $TMPDIR/etcd/memberlist 2>&1
-  docker exec etcd etcdctl endpoint status --endpoints=$(docker exec etcd /bin/sh -c "etcdctl $PARAM member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','") --write-out table > $TMPDIR/etcd/endpointstatus 2>&1
-  docker exec etcd etcdctl endpoint health --endpoints=$(docker exec etcd /bin/sh -c "etcdctl $PARAM member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','") > $TMPDIR/etcd/endpointhealth 2>&1
-  docker exec etcd sh -c "etcdctl $PARAM alarm list" > $TMPDIR/etcd/alarmlist 2>&1
 fi
-
-# nginx-proxy
-echo "Collecting nginx-proxy info"
-if docker inspect nginx-proxy >/dev/null 2>&1; then
-  mkdir -p $TMPDIR/k8s/nginx-proxy
-  docker exec nginx-proxy cat /etc/nginx/nginx.conf > $TMPDIR/k8s/nginx-proxy/nginx.conf 2>&1
+sherlock
+system-all
+networking
+if [[ "${OSRELEASE}" = "rhel" || "${OSRELEASE}" = "centos" ]]
+  then
+    system-rhel
+elif [ "${OSRELEASE}" = "ubuntu" ]
+  then
+    system-ubuntu
 fi
-
-FILEDIR=$(dirname $TMPDIR)
-FILENAME="$(hostname)-$(date +'%Y-%m-%d_%H_%M_%S').tar"
-tar cf $FILEDIR/$FILENAME -C ${TMPDIR}/ .
-
-if $(command -v gzip >/dev/null 2>&1); then
-  echo "Compressing archive to ${FILEDIR}/${FILENAME}.gz"
-  gzip ${FILEDIR}/${FILENAME}
-  FILENAME="${FILENAME}.gz"
+if [ "${RUNTIME}" = "docker" ]
+  then
+    docker-logs
+    docker-rancher
+    etcd
+elif [ "${RUNTIME}" = "k3s" ]
+  then
+    k3s-logs
+    k3s-rancher
 fi
-
-echo "Created ${FILEDIR}/${FILENAME}"
-echo "You can now remove ${TMPDIR}"
+var-log
+if [ "${INIT}" = " systemd" ]
+  then
+    journald-log
+fi
+certs
+archive
+cleanup


### PR DESCRIPTION
- Break into functions to improve logic and readability
- Add detection of k3s and journald and log collect
- Check for available disk space
- Bring variables to top of script for visibility
- Add kubectl output for svc, nodes, pods, endpoints
- Remove tmp directory after collection
- Add timestamps to script output
- Add help menu
- Add [ipvsadm](https://github.com/rancherlabs/support-tools/issues/29) output

Tested on: CentOS 7.7, Ubuntu 18.04, OEL 7.7, Rancher OS 1.5.5