### PR TITLE
Correct logic error on daemon.json copy

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -222,7 +222,7 @@ docker-logs() {
   docker images > $TMPDIR/docker/dockerstats 2>&1 & timeout_cmd
 
   if [ -f /etc/docker/daemon.json ]; then
-    cp -p /etc/docker/daemon.json > $TMPDIR/docker/etcdockerdaemon.json
+    cp -p /etc/docker/daemon.json $TMPDIR/docker/etcdockerdaemon.json
   fi
 
 }


### PR DESCRIPTION
This line throws an error because you are trying a copy operation but then doing a redirect to the destination.    Removed the redirect to correct syntax error.