### PR TITLE
Adding sed to redact Rancher agent token

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -279,7 +279,7 @@ docker-rancher() {
 
   for RANCHERAGENT in $RANCHERAGENTS; do
     docker inspect $RANCHERAGENT > $TMPDIR/rancher/containerinspect/agent-$RANCHERAGENT 2>&1
-    docker logs $SINCE_FLAG -t $RANCHERAGENT > $TMPDIR/rancher/containerlogs/agent-$RANCHERAGENT 2>&1
+    docker logs $SINCE_FLAG -t $RANCHERAGENT | sed 's/token.*/token REDACTED/g' > $TMPDIR/rancher/containerlogs/agent-$RANCHERAGENT 2>&1
   done
 
   # K8s Docker container logging

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -279,7 +279,7 @@ docker-rancher() {
 
   for RANCHERAGENT in $RANCHERAGENTS; do
     docker inspect $RANCHERAGENT > $TMPDIR/rancher/containerinspect/agent-$RANCHERAGENT 2>&1
-    docker logs $SINCE_FLAG -t $RANCHERAGENT | sed 's/token.*/token REDACTED/g' > $TMPDIR/rancher/containerlogs/agent-$RANCHERAGENT 2>&1
+    docker logs $SINCE_FLAG -t $RANCHERAGENT 2>&1 | sed 's/with token.*/with token REDACTED/g' > $TMPDIR/rancher/containerlogs/agent-$RANCHERAGENT 2>&1
   done
 
   # K8s Docker container logging


### PR DESCRIPTION
Adding `sed 's/token.*/token REDACTED/g'` in-order to redact the Rancher agent token for the Rancher agent logs.