### PR TITLE
Create rancher2_determine_leader.sh

### DIFF
--- a/troubleshooting-scripts/README.md
+++ b/troubleshooting-scripts/README.md
@@ -18,7 +18,8 @@ Command(s): `curl -s https://raw.githubusercontent.com/support-tools/troubleshoo
 
 **Example Output**
 
-```bashNAME                                    POD-IP         HOST-IP
+```bash
+NAME                                    POD-IP         HOST-IP
 cattle-cluster-agent-776d795ff8-x77nq   10.42.0.93     10.10.100.83
 cattle-node-agent-4bsx6                 10.10.100.83   10.10.100.83
 rancher-54d47dc9cf-d4qt9                10.42.0.92     10.10.100.83

--- a/troubleshooting-scripts/README.md
+++ b/troubleshooting-scripts/README.md
@@ -3,9 +3,27 @@
 ## kube-scheduler
 
 ### Finding the current leader
+
 Command(s): `curl -s https://raw.githubusercontent.com/support-tools/troubleshooting-scripts/kube-scheduler/find-leader.sh | bash`
 
 **Example Output**
+
 ```bash
 kube-scheduler is the leader on node a1ubk8slabl03
+```
+
+## determine-leader
+
+Command(s): `curl -s https://raw.githubusercontent.com/support-tools/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh | bash`
+
+**Example Output**
+
+```bashNAME                                    POD-IP         HOST-IP
+cattle-cluster-agent-776d795ff8-x77nq   10.42.0.93     10.10.100.83
+cattle-node-agent-4bsx6                 10.10.100.83   10.10.100.83
+rancher-54d47dc9cf-d4qt9                10.42.0.92     10.10.100.83
+rancher-54d47dc9cf-prn4d                10.42.0.90     10.10.100.83
+rancher-54d47dc9cf-rsn4g                10.42.0.91     10.10.100.83
+
+rancher-54d47dc9cf-prn4d is the leader in this Rancher instance
 ```

--- a/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
+++ b/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-LEADER="$(kubectl -n kube-system get configmap cattle-controllers -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io/leader}' | jq . 2>/dev/null | grep 'holderIdentity' | awk '{print $2}' | tr -d ",\"" | awk -F '_' '{print $1}')"
-echo "$LEADER is the leader in this Rancher instance"
+RANCHER_LEADER="$(kubectl -n kube-system get configmap cattle-controllers -o json | jq -r '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"' | jq -r '.holderIdentity')"
+# Display Rancher Pods Information
+kubectl get pod -n cattle-system $LEADER -o custom-columns=NAME:.metadata.name,POD-IP:.status.podIP,HOST-IP:.status.hostIP
+printf "\n$RANCHER_LEADER is the leader in this Rancher instance\n"

--- a/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
+++ b/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+LEADER="$(kubectl -n kube-system get configmap cattle-controllers -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io/leader}' | jq . 2>/dev/null | grep 'holderIdentity' | awk '{print $2}' | tr -d ",\"" | awk -F '_' '{print $1}')"
+echo "$LEADER is the leader in this Rancher instance"


### PR DESCRIPTION
I noticed I was getting different results depending on how Rancher was deployed:

1. RKE cluster:

```sh
rancher-54d47dc9cf-prn4d is the leader in this Rancher instance
```

My RKE cluster is a single node running in AWS.

2. Local docker image:

```sh
4cfbfe99582c is the leader in this Rancher instance
```

The local docker image was spun up using this command:

```sh
sudo docker run -d --name rancher-2.5 --restart=unless-stopped -p 80:80 -p 443:443 --privileged rancher/rancher:v2.5.1
```
