### PR TITLE
Prefer systemd when restarting docker, correct flag usage

### DIFF
--- a/extended-rancher-2-cleanup/README.md
+++ b/extended-rancher-2-cleanup/README.md
@@ -19,8 +19,8 @@ Rancher 2.x extended cleanup
 
   All flags are optional
 
-  -f | --flush-images       Cleanup all container images
-  -i | --flush-iptables     Flush all iptables rules (includes a Docker restart)
+  -f | --flush-iptables     Flush all iptables rules (includes a Docker restart)
+  -i | --flush-images       Cleanup all container images
   -h                        This help menu
 
   !! Warning, this script removes containers and all data specific to Kubernetes and Rancher

--- a/extended-rancher-2-cleanup/extended-cleanup-rancher2.sh
+++ b/extended-rancher-2-cleanup/extended-cleanup-rancher2.sh
@@ -101,7 +101,12 @@ flush-iptables() {
   iptables -F
   iptables -X
   techo "Restarting Docker..."
-  /etc/init.d/docker restart
+  if systemctl list-units --full -all | grep -q docker.service
+    then
+      systemctl restart docker
+    else
+      /etc/init.d/docker restart
+  fi
 
 }
 
@@ -112,8 +117,8 @@ help() {
 
   All flags are optional
 
-  -f | --flush-images       Cleanup all container images
-  -i | --flush-iptables     Flush all iptables rules (includes a Docker restart)
+  -f | --flush-iptables     Flush all iptables rules (includes a Docker restart)
+  -i | --flush-images       Cleanup all container images
   -h                        This help menu
 
   !! Warning, this script removes containers and all data specific to Kubernetes and Rancher


### PR DESCRIPTION
Prefer systemd, `/etc/init.d/docker` is often not created, use `systemctl` to restart docker

Corrected the incorrect flags in the usage