### PR TITLE
Adding bad ingress scanner script

### DIFF
--- a/bad-ingress-scanner/Dockerfile
+++ b/bad-ingress-scanner/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:latest
+MAINTAINER Matthew Mattox <matt.mattox@suse.com>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    apt-utils \
+    curl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+## Install kubectl
+RUN curl -kLO "https://storage.googleapis.com/kubernetes-release/release/$(curl -ks https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+chmod u+x kubectl && \
+mv kubectl /usr/local/bin/kubectl
+
+COPY *.sh /root/
+RUN chmod +x /root/*.sh
+CMD /root/run.sh

--- a/bad-ingress-scanner/README.md
+++ b/bad-ingress-scanner/README.md
@@ -1,7 +1,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/cube8021/bad-ingress-scanner.svg)](https://hub.docker.com/r/cube8021/bad-ingress-scanner)
 
 # Bad ingress scanner
-This tools is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-extent SSL cert or an ingress an empty / missing backend service.
+This tool is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-extent SSL cert or an ingress with an empty/missing backend service.
 
 ## Running report
 ```bash

--- a/bad-ingress-scanner/README.md
+++ b/bad-ingress-scanner/README.md
@@ -1,7 +1,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/cube8021/bad-ingress-scanner.svg)](https://hub.docker.com/r/cube8021/bad-ingress-scanner)
 
 # Bad ingress scanner
-This tool is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-extent SSL cert or an ingress with an empty/missing backend service.
+This tool is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-existent SSL cert or an ingress with an empty/missing backend service.
 
 ## Running report - remotely
 ```bash

--- a/bad-ingress-scanner/README.md
+++ b/bad-ingress-scanner/README.md
@@ -3,7 +3,14 @@
 # Bad ingress scanner
 This tool is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-extent SSL cert or an ingress with an empty/missing backend service.
 
-## Running report
+## Running report - remotely
+```bash
+wget -o ingress-scanner.sh https://raw.githubusercontent.com/rancherlabs/support-tools/master/bad-ingress-scanner/run.sh
+chmod +x ./ingress-scanner.sh
+./ingress-scanner.sh
+```
+
+## Running report - in-cluster
 ```bash
 kubectl -n ingress-nginx delete job ingress-scanner
 kubectl apply -f deployment.yaml
@@ -11,7 +18,7 @@ kubectl -n ingress-nginx logs -l app=ingress-scanner
 ```
 
 ## Example output
-```
+```bash
 Pod: nginx-ingress-controller-r8kkz
 ####################################################################
 Found bad endpoints.
@@ -27,4 +34,15 @@ default/test-02-example-com
 ## Removing
 ```bash
 kubectl delete -f deployment.yaml
+```
+
+## Deploying test ingress rules
+Note: These rules are designed to be broken/invalid and are deployed to the default namespace.
+```bash
+kubectl apply -f bad-ingress.yaml
+```
+
+## Removing test ingress rules
+```bash
+kubectl delete -f bad-ingress.yaml
 ```

--- a/bad-ingress-scanner/README.md
+++ b/bad-ingress-scanner/README.md
@@ -1,0 +1,16 @@
+[![Docker Pulls](https://img.shields.io/docker/pulls/cube8021/bad-ingress-scanner.svg)](https://hub.docker.com/r/cube8021/bad-ingress-scanner)
+
+# Bad ingress scanner
+This tools is designed to scan for misbehaving ingresses. An example being an ingress that was deployed refencing a non-extent SSL cert or an ingress an empty / missing backend service.
+
+## Running report
+```bash
+kubectl -n ingress-nginx delete job ingress-scanner
+kubectl apply -f deployment.yaml
+kubectl -n ingress-nginx logs -l app=ingress-scanner
+```
+
+## Removing
+```bash
+kubectl delete -f deployment.yaml
+```

--- a/bad-ingress-scanner/README.md
+++ b/bad-ingress-scanner/README.md
@@ -1,13 +1,27 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/cube8021/bad-ingress-scanner.svg)](https://hub.docker.com/r/cube8021/bad-ingress-scanner)
 
 # Bad ingress scanner
-This tools is designed to scan for misbehaving ingresses. An example being an ingress that was deployed refencing a non-extent SSL cert or an ingress an empty / missing backend service.
+This tools is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-extent SSL cert or an ingress an empty / missing backend service.
 
 ## Running report
 ```bash
 kubectl -n ingress-nginx delete job ingress-scanner
 kubectl apply -f deployment.yaml
 kubectl -n ingress-nginx logs -l app=ingress-scanner
+```
+
+## Example output
+```
+Pod: nginx-ingress-controller-r8kkz
+####################################################################
+Found bad endpoints.
+default/ingress-75f627ce3d0ccd29dd268e0ab2b37008
+default/test-01-example-com
+default/test-02-example-com
+####################################################################
+Found bad certs.
+default/test-01-example-com
+default/test-02-example-com
 ```
 
 ## Removing

--- a/bad-ingress-scanner/bad-ingress.yaml
+++ b/bad-ingress-scanner/bad-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: test-01
@@ -9,10 +9,14 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: test-01-example-com
-          servicePort: 80
+          service:
+            name: test-01-example-com
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: test-02
@@ -22,14 +26,18 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: test-02-example-com
-          servicePort: 80
+          service:
+            name: test-02-example-com
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
   tls:
   - hosts:
     - test-02.example.com
     secretName: test-02-example-com
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: test-02-dup
@@ -39,8 +47,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: test-02-example-com
-          servicePort: 80
+          service:
+            name: test-02-example-com
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
   tls:
   - hosts:
     - test-02.example.com

--- a/bad-ingress-scanner/bad-ingress.yaml
+++ b/bad-ingress-scanner/bad-ingress.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-01
+spec:
+  rules:
+  - host: test-01.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: test-01-example-com
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-02
+spec:
+  rules:
+  - host: test-02.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: test-02-example-com
+          servicePort: 80
+  tls:
+  - hosts:
+    - test-02.example.com
+    secretName: test-02-example-com
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-02-dup
+spec:
+  rules:
+  - host: test-02.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: test-02-example-com
+          servicePort: 80
+  tls:
+  - hosts:
+    - test-02.example.com
+    secretName: test-02-example-com

--- a/bad-ingress-scanner/deployment.yaml
+++ b/bad-ingress-scanner/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingress-scanner
+  namespace: ingress-nginx
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ingress-scanner
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-scanner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-scanner
+subjects:
+- kind: ServiceAccount
+  name: ingress-scanner
+  namespace: ingress-nginx
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ingress-scanner
+  namespace: ingress-nginx
+spec:
+  backoffLimit: 10
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: ingress-scanner
+        job-name: ingress-scanner
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+      containers:
+      - image: cube8021/bad-ingress-scanner:v0.1
+        imagePullPolicy: IfNotPresent
+        name: ingress-scanner
+      restartPolicy: Never
+      serviceAccount: ingress-scanner
+      serviceAccountName: ingress-scanner
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists

--- a/bad-ingress-scanner/run.sh
+++ b/bad-ingress-scanner/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "####################################################################"
+echo "Scanning ingress controllers..."
+for ingressPod in `kubectl -n ingress-nginx get pods -l app=ingress-nginx -o name | awk -F'/' '{print $2}'`
+do
+  echo "Pod: $ingressPod"
+  kubectl -n ingress-nginx logs "$ingressPod" | grep 'Error obtaining Endpoints for Service' | awk -F '"' '{print $2}' > ./bad-endpoints.list
+  kubectl -n ingress-nginx logs "$ingressPod" | grep 'Error getting SSL certificate' | awk -F '"' '{print $2}' > ./bad-certs.list
+done
+echo "####################################################################"
+echo "Sorting and removing duplicates from lists..."
+cat ./bad-endpoints.list | sort | uniq > ./bad-endpoints.list2
+mv ./bad-endpoints.list2 ./bad-endpoints.list
+cat ./bad-certs.list | sort | uniq > ./bad-certs.list2
+mv ./bad-certs.list2 ./bad-certs.list
+
+if [[ ! -z `cat ./bad-endpoints.list` ]]
+then
+  echo "####################################################################"
+  echo "Found bad endpoints."
+  cat ./bad-endpoints.list
+else
+  echo "####################################################################"
+  echo "No bad endpoints found."
+fi
+
+if [[ ! -z `cat ./bad-certs.list` ]]
+then
+  echo "####################################################################"
+  echo "Found bad certs."
+  cat ./bad-certs.list
+else
+  echo "####################################################################"
+  echo "No bad endpoints found."
+fi


### PR DESCRIPTION
This tool is designed to scan for misbehaving ingresses. An example being an ingress that was deployed referencing a non-extent SSL cert or an ingress with an empty/missing backend service.