### PR TITLE
Rancher metadata

### DIFF
--- a/rancher-metadata-syncer/Dockerfile
+++ b/rancher-metadata-syncer/Dockerfile
@@ -1,0 +1,34 @@
+## Running builder to download metadata files
+FROM ubuntu:18.04 AS builder
+MAINTAINER Matthew Mattox matt.mattox@suse.com
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+apt-utils \
+wget \
+&& apt-get clean && rm -rf /var/lib/apt/lists/*
+ADD *.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/*.sh
+WORKDIR /root/
+RUN /usr/local/bin/download.sh
+
+## Building webserver
+FROM ubuntu:18.04
+MAINTAINER Matthew Mattox matt.mattox@suse.com
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+apt-utils \
+apache2 \
+&& apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN a2enmod rewrite expires
+RUN echo "ServerName localhost" | tee /etc/apache2/conf-available/servername.conf
+RUN a2enconf servername
+COPY apache.conf /etc/apache2/sites-available/
+RUN a2dissite 000-default
+RUN a2ensite apache.conf
+RUN ln -sf /proc/self/fd/1 /var/log/apache2/access.log && \
+    ln -sf /proc/self/fd/1 /var/log/apache2/error.log
+EXPOSE 80
+WORKDIR /var/www/src
+COPY --from=builder /root/*.json /var/www/src/
+COPY --from=builder /usr/local/bin/*.sh /usr/local/bin/
+CMD /usr/local/bin/run.sh

--- a/rancher-metadata-syncer/README.md
+++ b/rancher-metadata-syncer/README.md
@@ -1,0 +1,73 @@
+# rancher-metadata-syncer
+Rancher Metadata Syncer is a simple pod for publishing the Rancher metadata.json in an airgap setup to allow Rancher to get updated metadata files without granting Rancher internet access or upgrading Rancher.
+
+## Installation
+
+Note: The following tool should only be deployed on the Rancher Local cluster and not on a downstream cluster.
+
+### Option A - Configmap
+The configmap option is used when you would like to add the metadata files via a Configmap.
+Note: The following steps should be run from a server/workstation with internet access.
+
+- Download the metadata file(s)
+
+```bash
+wget --no-check-certificate -O v2-4.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json
+wget --no-check-certificate -O v2-5.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.5/data.json
+```
+
+- Create the Configmap with the metadata files.
+
+```bash
+kubectl -n cattle-system create configmap rancher-metadata --from-file=v2-4.json=./v2-4.json --from-file=v2-4.json=./v2-5.json
+```
+
+- Deploy the workload
+```bash
+kubectl apply -f deployment-configmap.yaml
+```
+
+- If you would update the metadata file, please do the following.
+```bash
+wget --no-check-certificate -O v2-4.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json
+wget --no-check-certificate -O v2-5.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.5/data.json
+kubectl -n cattle-system delete configmap rancher-metadata
+kubectl -n cattle-system create configmap rancher-metadata --from-file=v2-4.json=./v2-4.json --from-file=v2-4.json=./v2-5.json
+kubectl -n cattle-system patch deployment rancher-metadata -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"$(date +%s)\"}}}}}"
+```
+
+### Option B - Proxy
+The proxy option is used if you would like the deployment to automatedly download the metadata files every 6 hours without opening all of Rancher to the internet via the Proxy.
+
+- Edit values HTTP_PROXY and HTTPS_PROXY in deployment-proxy.yaml match your environment requirements.
+```bash
+- name: HTTPS_PROXY
+  value: "https://<user>:<password>@<ip_addr>:<port>/"
+- name: HTTP_PROXY
+  value: "http://<user>:<password>@<ip_addr>:<port>/"
+```
+
+- Deploy the workload
+```bash
+kubectl apply -f deployment-proxy.yaml
+```
+
+## Updating Rancher
+
+- Browse to the Rancher UI -> Global -> Settings -> rke-metadata-config
+
+- Update the value to the following for Rancher v2.4.x
+```
+{
+  "refresh-interval-minutes": "60",
+  "url": "http://rancher-metadata/v2-4.json"
+}
+```
+
+- Update the value to the following for Rancher v2.5.x
+```
+{
+  "refresh-interval-minutes": "60",
+  "url": "http://rancher-metadata/v2-5.json"
+}
+```

--- a/rancher-metadata-syncer/README.md
+++ b/rancher-metadata-syncer/README.md
@@ -6,7 +6,7 @@ Rancher Metadata Syncer is a simple pod for publishing the Rancher metadata.json
 Note: The following tool should only be deployed on the Rancher Local cluster and not on a downstream cluster.
 
 ### Option A - Configmap
-The configmap option is used when you would like to add the metadata files via a Configmap.
+The Configmap option is used when you would like to add the metadata files via a Configmap.
 Note: The following steps should be run from a server/workstation with internet access.
 
 - Download the metadata file(s)

--- a/rancher-metadata-syncer/apache.conf
+++ b/rancher-metadata-syncer/apache.conf
@@ -1,0 +1,14 @@
+<VirtualHost *:80>
+  ServerAdmin admin@localhost
+  ServerName localhost
+  DocumentRoot /var/www/src
+  <Directory /var/www/src/>
+    Options Indexes FollowSymLinks MultiViews
+    AllowOverride All
+    Order allow,deny
+    Allow from all
+    Require all granted
+  </Directory>
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/rancher-metadata-syncer/deployment-configmap.yaml
+++ b/rancher-metadata-syncer/deployment-configmap.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: rancher-metadata
+  name: rancher-metadata
+  namespace: cattle-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rancher-metadata
+  template:
+    metadata:
+      labels:
+        app: rancher-metadata
+    spec:
+      containers:
+      - image: cube8021/rancher-metadata-airgap:latest
+        imagePullPolicy: IfNotPresent
+        name: rancher-metadata
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - mountPath: /data
+          name: metadata
+      volumes:
+      - configMap:
+          defaultMode: 256
+          name: rancher-metadata
+          optional: false
+        name: metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rancher-metadata
+  namespace: cattle-system
+spec:
+  selector:
+    app: rancher-metadata-airgap
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/rancher-metadata-syncer/deployment-proxy.yaml
+++ b/rancher-metadata-syncer/deployment-proxy.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: rancher-metadata
+  name: rancher-metadata
+  namespace: cattle-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rancher-metadata
+  template:
+    metadata:
+      labels:
+        app: rancher-metadata
+    spec:
+      containers:
+      - env:
+        - name: HTTPS_PROXY
+          value: https://<user>:<password>@<ip_addr>:<port>/
+        - name: HTTP_PROXY
+          value: http://<user>:<password>@<ip_addr>:<port>/
+        image: cube8021/rancher-metadata-airgap:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: rancher-metadata
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rancher-metadata
+  namespace: cattle-system
+spec:
+  selector:
+    app: rancher-metadata-airgap
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/rancher-metadata-syncer/download.sh
+++ b/rancher-metadata-syncer/download.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Downloading kontainer-driver-metadata for v2.4"
+wget --no-check-certificate -O v2-4.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json
+
+echo "Downloading kontainer-driver-metadata for v2.5"
+wget --no-check-certificate -O v2-5.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.5/data.json

--- a/rancher-metadata-syncer/run.sh
+++ b/rancher-metadata-syncer/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+echo "Starting webserver..."
+apachectl start
+echo "ok" > /var/www/src/healthz
+if [[ ! -z $HTTP_PROXY ]] || [[ ! -z $http_prozy ]] || [[ ! -z $HTTPS_PROXY ]] || [[ ! -z $https_prozy ]]
+then
+  echo "Detected proxy settings."
+  echo "Starting downloader..."
+  while true
+  do
+    /usr/local/bin/download.sh
+    echo "Sleeping..."
+    sleep 6h
+  done
+fi
+
+if [[ -d /data ]]
+then
+  echo "Configmap detected, loading json files from Configmap..."
+  cp -f /data/*.json /var/www/src/
+fi
+
+echo "Starting in static mode"
+while true
+do
+  sleep 10000
+done


### PR DESCRIPTION
Rancher Metadata Syncer is a simple pod for publishing the Rancher metadata.json in an airgap setup to allow Rancher to get updated metadata files without granting Rancher internet access or upgrading Rancher.

Please see ZD-13961 for more details.