### PR TITLE
Cleanup evicted pods left behind after disk pressure

### DIFF
--- a/cleanup-evicted-pods/README.md
+++ b/cleanup-evicted-pods/README.md
@@ -11,8 +11,15 @@ kubectl get pods --all-namespaces -ojson | jq -r '.items[] | select(.status.reas
 ### Automatic cleanup
 This is a cronjob that runs every 30 mins inside the cluster that will find and remove any pods with the status of "Evicted."
 
-NOTE: Uses the image `rancher/hyperkube:v1.19.6-rancher1`. This can be changed to match your cluster version by matching the same image tag rke addon jobs in the kube-system.
-
 ```bash
 kubectl apply -f deploy.yaml
 ```
+
+NOTE: This YAML uses the image `rancher/hyperkube:v1.19.6-rancher1`. 
+Use below command to get the image path for your cluster and modify the YAML if needed.
+```
+kubectl get jobs -n kube-system rke-network-plugin-deploy-job -o jsonpath='{.spec.template.spec.containers[].image}' && echo
+```
+Also make sure to modify the image after every Kubernetes version upgrade.
+
+

--- a/cleanup-evicted-pods/README.md
+++ b/cleanup-evicted-pods/README.md
@@ -1,0 +1,16 @@
+# Cleanup evicted pods left behind after disk pressure
+When a node starts to evict pods under disk pressure, the evicted pods are left behind. All the resources like volumes, IP, containers, etc will be cleaned up and delete. But the pod object will be left behind in "evicted" status. Per upstream this is [intentional](https://github.com/kubernetes/kubernetes/issues/54525#issuecomment-340035375)
+
+## Workaround
+
+### Manual cleanup
+```bash
+kubectl get pods --all-namespaces -ojson | jq -r '.items[] | select(.status.reason!=null) | select(.status.reason | contains("Evicted")) | .metadata.name + " " + .metadata.namespace' | xargs -n2 -l bash -c 'kubectl delete pods $0 --namespace=$1'
+```
+
+### Automatic cleanup
+NOTE: Uses the image `rancher/hyperkube:v1.19.6-rancher1`. This can be changed to match your cluster version by matching the same image tag rke addon jobs in the kube-system.
+
+```bash
+kubectl apply -f deploy.yaml
+```

--- a/cleanup-evicted-pods/README.md
+++ b/cleanup-evicted-pods/README.md
@@ -4,6 +4,7 @@ When a node starts to evict pods under disk pressure, the evicted pods are left 
 ## Workaround
 
 ### Manual cleanup
+NOTE: This script is designed to work on Linux machines.
 ```bash
 kubectl get pods --all-namespaces -ojson | jq -r '.items[] | select(.status.reason!=null) | select(.status.reason | contains("Evicted")) | .metadata.name + " " + .metadata.namespace' | xargs -n2 -l bash -c 'kubectl delete pods $0 --namespace=$1'
 ```
@@ -15,11 +16,4 @@ This is a cronjob that runs every 30 mins inside the cluster that will find and 
 kubectl apply -f deploy.yaml
 ```
 
-NOTE: This YAML uses the image `rancher/hyperkube:v1.19.6-rancher1`. 
-Use below command to get the image path for your cluster and modify the YAML if needed.
-```
-kubectl get jobs -n kube-system rke-network-plugin-deploy-job -o jsonpath='{.spec.template.spec.containers[].image}' && echo
-```
-Also make sure to modify the image after every Kubernetes version upgrade.
-
-
+NOTE: This YAML uses the image `rancherlabs/swiss-army-knife`.

--- a/cleanup-evicted-pods/README.md
+++ b/cleanup-evicted-pods/README.md
@@ -9,6 +9,8 @@ kubectl get pods --all-namespaces -ojson | jq -r '.items[] | select(.status.reas
 ```
 
 ### Automatic cleanup
+This is a cronjob that runs every 30 mins inside the cluster that will find and remove any pods with the status of "Evicted."
+
 NOTE: Uses the image `rancher/hyperkube:v1.19.6-rancher1`. This can be changed to match your cluster version by matching the same image tag rke addon jobs in the kube-system.
 
 ```bash

--- a/cleanup-evicted-pods/deploy.yaml
+++ b/cleanup-evicted-pods/deploy.yaml
@@ -7,6 +7,7 @@ metadata:
     app: cleanup-evicted-pods
 spec:
   schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:

--- a/cleanup-evicted-pods/deploy.yaml
+++ b/cleanup-evicted-pods/deploy.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-evicted-pods
+  namespace: kube-system
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleanup-evicted-pods
+            image: rancher/hyperkube:v1.19.6-rancher1
+            imagePullPolicy: IfNotPresent
+            command: ["sh", "-c", "kubectl get pods --all-namespaces --field-selector 'status.phase==Failed' -o json | kubectl delete -f -"]
+          restartPolicy: OnFailure
+          serviceAccount: rke-job-deployer
+          serviceAccountName: rke-job-deployer

--- a/cleanup-evicted-pods/deploy.yaml
+++ b/cleanup-evicted-pods/deploy.yaml
@@ -3,6 +3,8 @@ kind: CronJob
 metadata:
   name: cleanup-evicted-pods
   namespace: kube-system
+  labels:
+    app: cleanup-evicted-pods
 spec:
   schedule: "*/30 * * * *"
   jobTemplate:

--- a/cleanup-evicted-pods/deploy.yaml
+++ b/cleanup-evicted-pods/deploy.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: cleanup-evicted-pods
-            image: rancher/hyperkube:v1.19.6-rancher1
+            image: rancherlabs/swiss-army-knife
             imagePullPolicy: IfNotPresent
             command: ["sh", "-c", "kubectl get pods --all-namespaces --field-selector 'status.phase==Failed' -o json | kubectl delete -f -"]
           restartPolicy: OnFailure


### PR DESCRIPTION
When a node starts to evict pods under disk pressure, the evicted pods are left behind. All the resources like volumes, IP, containers, etc will be cleaned up and delete. But the pod object will be left behind in "evicted" status. Per upstream this is [intentional](https://github.com/kubernetes/kubernetes/issues/54525#issuecomment-340035375)