### PR TITLE
Adding rancher-pod-collector script

### DIFF
--- a/collection/rancher/v2.x/rancher-pod-collector/README.md
+++ b/collection/rancher/v2.x/rancher-pod-collector/README.md
@@ -1,0 +1,34 @@
+# rancher-logs-collector
+
+The script needs to be downloaded and run on one of the following servers.
+
+* A server or workstation with kubectl access to the local cluster.
+* Directly on one of the local cluster nodes using the `root` user or using `sudo`.
+* As a k8s deployment on the local cluster.
+
+## How to use
+
+* Download the script and save as: `rancher-pod-collector.sh`
+* Make sure the script is executable: `chmod +x rancher-pod-collector.sh`
+* Run the script: `./rancher-pod-collector.sh`
+
+The script will create a .tar.gz log collection in /tmp by default, all flags are optional.
+
+## Flags
+
+```
+Rancher Pod Collector
+Usage: rancher-pod-collector.sh [ -d <directory> -k KUBECONFIG -t -w -f ]
+
+All flags are optional.
+
+-d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
+-k    Override the kubeconfig (ex: ~/.kube/custom)
+-t    Enable trace logs
+-w    Live tailing Rancher logs
+-f    Force log collection if the minimum space isn't available."
+```
+
+## Important disclaimer
+
+The flag `-t` will enables trace logging. This can capture sensitive information about your Rancher install, including but not limited to usernames, passwords, encryption keys, etc.

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
-# Rancher 2.x Pod collector for supported Linux distributions
-# https://rancher.com/support-maintenance-terms#rancher-support-matrix
-
-# Minimum space needed to run the script (MB)
-SPACE=512
-
-# Set TIMEOUT in seconds for select commands
-TIMEOUT=60
+SPACE="512"
+TIMEOUT="60"
 
 setup() {
 
@@ -39,7 +33,7 @@ verify-access() {
     ## We are inside the k8s cluster or we're using the local kubeconfig
     RANCHER_POD=$(kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name | head -n1)
     KUBECTL_CMD="kubectl -n cattle-system exec -c rancher ${RANCHER_POD} -- kubectl"
-  elif$(command -v k3s >/dev/null 2>&1)
+  elif $(command -v k3s >/dev/null 2>&1)
   then
     ## We are on k3s node
     KUBECTL_CMD="k3s kubectl"

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -108,14 +108,14 @@ disable-debug() {
 watch-logs() {
 
   techo "Live tailing debug logs from Rancher pods"
-  techo "Please use Ctrl+C to continue"
+  techo "Please use Ctrl+C to finish tailing"
   mkdir -p $TMPDIR/rancher-logs/
   ${KUBECTL_CMD} -n cattle-system logs -f -l app=rancher -c rancher | tee $TMPDIR/rancher-logs/live-logs
 
 }
 
 
-pause(){
+pause() {
 
  read -n1 -rsp $'Press any key once finished logging with debug loglevel, or Ctrl+C to exit and leave debug loglevel enabled... \n'
 

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 SPACE="512"
-TIMEOUT="60"
 
 setup() {
 

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -142,7 +142,7 @@ help() {
   -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
   -r    Override container runtime if not automatically detected (docker|k3s)
   -k    Override the kubeconfig (ex: ~/.kube/custom)
-  -t    Enable tracve logs
+  -t    Enable trace logs
   -f    Force log collection if the minimum space isn't available"
 
 }

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -25,9 +25,11 @@ verify-access() {
   if [[ ! -z $OVERRIDE_KUBECONFIG ]];
   then
     ## Just use the kubeconfig that was set by the user
-    RANCHER_POD=$(kubectl --kubeconfig $OVERRIDE_KUBECONFIG -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name | head -n1)
-    KUBECTL_CMD="kubectl --kubeconfig $OVERRIDE_KUBECONFIG -n cattle-system exec -c rancher ${RANCHER_POD} -- kubectl"
-  elif [[ ! -z $KUBERNETES_PORT ]] || [[ ! -z $KUBECONFIG ]];
+    KUBECTL_CMD="kubectl --kubeconfig $OVERRIDE_KUBECONFIG"
+  elif [[ ! -z $KUBECONFIG ]];
+  then
+    KUBECTL_CMD="kubectl"
+  elif [[ ! -z $KUBERNETES_PORT ]];
   then
     ## We are inside the k8s cluster or we're using the local kubeconfig
     RANCHER_POD=$(kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name | head -n1)

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -67,7 +67,7 @@ cluster-info() {
   ${KUBECTL_CMD} get endpoints -n cattle-system -o wide > $TMPDIR/cattle-system/get-endpoints 2>&1
   ## Grabbing kube-system items
   mkdir -p $TMPDIR/kube-system/
-  ${KUBECTL_CMD} get configmap -n cattle-system cattle-controllers -o yaml > $TMPDIR/kube-system/get-configmap-cattle-controllers.yaml 2>&1
+  ${KUBECTL_CMD} get configmap -n kube-system cattle-controllers -o yaml > $TMPDIR/kube-system/get-configmap-cattle-controllers.yaml 2>&1
 
 }
 

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -144,12 +144,11 @@ cleanup() {
 help() {
 
   echo "Rancher Pod Collector
-  Usage: rancher-pod-collector.sh [ -d <directory> -r <container runtime> -k KUBECONFIG -t -w -f ]
+  Usage: rancher-pod-collector.sh [ -d <directory> -k KUBECONFIG -t -w -f ]
 
   All flags are optional
 
   -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
-  -r    Override container runtime if not automatically detected (docker|k3s)
   -k    Override the kubeconfig (ex: ~/.kube/custom)
   -t    Enable trace logs
   -w    Live tailing Rancher logs
@@ -169,13 +168,10 @@ techo() {
 
 }
 
-while getopts ":d:r:k:ftwh" opt; do
+while getopts ":d:k:ftwh" opt; do
   case $opt in
     d)
       MKTEMP_BASEDIR="-p ${OPTARG}"
-      ;;
-    r)
-      RUNTIME_FLAG="${OPTARG}"
       ;;
     k)
       OVERRIDE_KUBECONFIG="${OPTARG}"

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# Rancher 2.x Pod collector for supported Linux distributions
+# https://rancher.com/support-maintenance-terms#rancher-support-matrix
+
+# Minimum space needed to run the script (MB)
+SPACE=512
+
+# Set TIMEOUT in seconds for select commands
+TIMEOUT=60
+
+setup() {
+
+  TMPDIR=$(mktemp -d $MKTEMP_BASEDIR)
+  techo "Created ${TMPDIR}"
+
+}
+
+disk-space() {
+
+  AVAILABLE=$(df -m ${TMPDIR} | tail -n 1 | awk '{ print $4 }')
+  if [ "${AVAILABLE}" -lt "${SPACE}" ]
+    then
+      techo "${AVAILABLE} MB space free, minimum needed is ${SPACE} MB."
+      DISK_FULL=1
+  fi
+
+}
+
+verify-access() {
+
+  techo "Verifying cluster access"
+  if [[ ! -z $OVERRIDE_KUBECONFIG ]];
+  then
+    ## Just use the kubeconfig that was set by the user
+    RANCHER_POD=$(kubectl --kubeconfig $OVERRIDE_KUBECONFIG -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name | head -n1)
+    KUBECTL_CMD="kubectl --kubeconfig $OVERRIDE_KUBECONFIG -n cattle-system exec -c rancher ${RANCHER_POD} -- kubectl"
+  elif [[ ! -z $KUBERNETES_PORT ]] || [[ ! -z $KUBECONFIG ]];
+  then
+    ## We are inside the k8s cluster or we're using the local kubeconfig
+    RANCHER_POD=$(kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name | head -n1)
+    KUBECTL_CMD="kubectl -n cattle-system exec -c rancher ${RANCHER_POD} -- kubectl"
+  elif$(command -v k3s >/dev/null 2>&1)
+  then
+    ## We are on k3s node
+    KUBECTL_CMD="k3s kubectl"
+  elif $(command -v docker >/dev/null 2>&1)
+  then
+    DOCKER_ID=$(docker ps | grep "k8s_rancher_rancher" | cut -d' ' -f1 | head -1)
+    KUBECTL_CMD="docker exec ${DOCKER_ID} kubectl"
+  else
+    ## Giving up
+    techo "Could not find a kubeconfig"
+  fi
+  if ! ${KUBECTL_CMD} cluster-info >/dev/null 2>&1
+  then
+    techo "Can not access cluster"
+    exit 1
+  else
+    techo "Cluster access has been verified"
+  fi
+}
+
+cluster-info() {
+
+  techo "Collecting cluster info"
+  mkdir -p $TMPDIR/clusterinfo
+  ${KUBECTL_CMD} cluster-info > $TMPDIR/clusterinfo/cluster-info 2>&1
+  ${KUBECTL_CMD} cluster-info dump > $TMPDIR/clusterinfo/cluster-info-dump 2>&1
+  ${KUBECTL_CMD} get nodes -o wide > $TMPDIR/clusterinfo/get-node-wide 2>&1
+  ## Grabbing cattle-system items
+  mkdir -p $TMPDIR/cattle-system/
+  ${KUBECTL_CMD} get pods -n cattle-system -o wide > $TMPDIR/cattle-system/get-pods 2>&1
+  ${KUBECTL_CMD} get svc -n cattle-system -o wide > $TMPDIR/cattle-system/get-svc 2>&1
+  ${KUBECTL_CMD} get endpoints -n cattle-system -o wide > $TMPDIR/cattle-system/get-endpoints 2>&1
+  ## Grabbing kube-system items
+  mkdir -p $TMPDIR/kube-system/
+  ${KUBECTL_CMD} get configmap -n cattle-system cattle-controllers -o yaml > $TMPDIR/kube-system/get-configmap-cattle-controllers.yaml 2>&1
+
+}
+
+enable-debug() {
+
+  techo "Enabling debug for Rancher pods"
+  for POD in $(${KUBECTL_CMD} get pods -n cattle-system -l app=rancher --no-headers | awk '{print $1}');
+  do
+    ${KUBECTL_CMD} exec -n cattle-system -c rancher $POD -- loglevel --set debug
+  done
+
+}
+
+disable-debug() {
+
+  techo "Enabling debug for Rancher pods"
+  for POD in $(${KUBECTL_CMD} get pods -n cattle-system -l app=rancher --no-headers | awk '{print $1}');
+  do
+    ${KUBECTL_CMD} exec -n cattle-system -c rancher $POD -- loglevel --set info
+  done
+
+}
+
+capture-logs() {
+
+  techo "Capturing debug logs from Rancher pods"
+  mkdir -p $TMPDIR/rancher-logs/
+  for POD in $(${KUBECTL_CMD} get pods -n cattle-system -l app=rancher --no-headers | awk '{print $1}');
+  do
+    ${KUBECTL_CMD} -n cattle-system -c rancher $POD logs > $TMPDIR/rancher-logs/$POD
+  done
+
+}
+
+pause(){
+ read -n1 -rsp $'Press any key to continue or Ctrl+C to exit...\n'
+}
+
+archive() {
+
+  FILEDIR=$(dirname $TMPDIR)
+  FILENAME="$(hostname)-$(date +'%Y-%m-%d_%H_%M_%S').tar"
+  tar --create --file ${FILEDIR}/${FILENAME} --directory ${TMPDIR}/ .
+  ## gzip separately for Rancher OS
+  gzip ${FILEDIR}/${FILENAME}
+
+  techo "Created ${FILEDIR}/${FILENAME}.gz"
+
+}
+
+cleanup() {
+
+  techo "Removing ${TMPDIR}"
+  rm -r -f "${TMPDIR}" >/dev/null 2>&1
+
+}
+
+help() {
+
+  echo "Rancher Pod Collector
+  Usage: rancher-pod-collector.sh [ -d <directory> -r <container runtime> -k KUBECONFIG -f ]
+
+  All flags are optional
+
+  -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
+  -r    Override container runtime if not automatically detected (docker|k3s)
+  -k    Override the kubeconfig (ex: ~/.kube/custom)
+  -f    Force log collection if the minimum space isn't available"
+
+}
+
+timestamp() {
+
+  date "+%Y-%m-%d %H:%M:%S"
+
+}
+
+techo() {
+
+  echo "$(timestamp): $*"
+
+}
+
+while getopts ":d:r:k:fh" opt; do
+  case $opt in
+    d)
+      MKTEMP_BASEDIR="-p ${OPTARG}"
+      ;;
+    r)
+      RUNTIME_FLAG="${OPTARG}"
+      ;;
+    k)
+      OVERRIDE_KUBECONFIG="${OPTARG}"
+      ;;
+    f)
+      FORCE=1
+      ;;
+    h)
+      help && exit 0
+      ;;
+    :)
+      techo "Option -$OPTARG requires an argument."
+      exit 1
+      ;;
+    *)
+      help && exit 0
+  esac
+done
+
+setup
+disk-space
+if [ -n "${DISK_FULL}" ]
+  then
+    if [ -z "${FORCE}" ]
+      then
+        techo "Cleaning up and exiting"
+        cleanup
+        exit 1
+      else
+        techo "-f (force) used, continuing"
+    fi
+fi
+
+verify-access
+cluster-info
+enable-debug
+pause
+disable-debug
+capture-logs
+archive
+cleanup

--- a/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
+++ b/collection/rancher/v2.x/rancher-pod-collector/rancher-pod-collector.sh
@@ -63,7 +63,7 @@ cluster-info() {
   mkdir -p $TMPDIR/clusterinfo
   ${KUBECTL_CMD} cluster-info > $TMPDIR/clusterinfo/cluster-info 2>&1
   ${KUBECTL_CMD} get nodes -o wide > $TMPDIR/clusterinfo/get-node-wide 2>&1
-  ${KUBECTL_CMD} cluster-info dump -o yaml -n cattle-system --log-file-max-size 500 --output-directory $TMPDIR/clusterinfo/cluster-info-dump
+  ${KUBECTL_CMD} cluster-info dump -o yaml -n cattle-system --log-file-max-size 200 --output-directory $TMPDIR/clusterinfo/cluster-info-dump
   ## Grabbing cattle-system items
   mkdir -p $TMPDIR/cattle-system/
   ${KUBECTL_CMD} get endpoints -n cattle-system -o wide > $TMPDIR/cattle-system/get-endpoints 2>&1
@@ -124,7 +124,7 @@ pause() {
 archive() {
 
   FILEDIR=$(dirname $TMPDIR)
-  FILENAME="$(hostname)-$(date +'%Y-%m-%d_%H_%M_%S').tar"
+  FILENAME="$(kubectl config view -o jsonpath='{.current-context}')-$(date +'%Y-%m-%d_%H_%M_%S').tar"
   tar --create --file ${FILEDIR}/${FILENAME} --directory ${TMPDIR}/ .
   ## gzip separately for Rancher OS
   gzip ${FILEDIR}/${FILENAME}


### PR DESCRIPTION
This script is designed to capture debug logs from the Rancher Pods. It using the following workflow.

- Tries to figure kubeconfig access (It allow the user to override the kubeconfig then tries to see if it's running inside the cluster, then tries the current loaded kubeconfig, then tries k3s/docker exec.
- Captures some data about the cluster (nodes, k8s versions, svc, etc)
- Turns on debug logging in all Rancher pods (loglevel --set debug)
- Gives the user a pause message to give them time to reproduce the issue
- Turns off debug logging in all Rancher pods (loglevel --set info)
- Capture logs for all Rancher pods
- Archive output (using the same process as log collector)