### PR TITLE
Adding NGINX-to-pods-check

### DIFF
--- a/NGINX-to-pods-check/README.md
+++ b/NGINX-to-pods-check/README.md
@@ -52,7 +52,7 @@ Checking Pod webserver-good-65644cffd4-gbpkj PodIP 10.42.0.251 on Port 80 in end
 
 ## Testing
 
-The following commands will deploy two workloads and ingresses. One that is working with a webserver that is responding on port 80. And the other will have the webserver disabled so it will fail to connect.
+The following commands will deploy two workloads and ingresses. One that is working with a web server that is responding on port 80. And the other will have the webserver disabled, so it will fail to connect.
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/master/NGINX-to-pods-check/example-deployment.yml

--- a/NGINX-to-pods-check/README.md
+++ b/NGINX-to-pods-check/README.md
@@ -1,0 +1,59 @@
+# NGINX-to-pods-check
+This script is designed to walk through all the ingresses in a cluster and test that it can curl the backend pods from the NGINX pods. This is mainly done to verify the overlay network is working along with checking the overall configurtion.
+
+## Run script
+```
+curl https://raw.githubusercontent.com/rancherlabs/support-tools/master/NGINX-to-pods-check/check.sh | bash
+```
+
+## Example output
+
+### Broken pod
+
+```
+bash ./check.sh -F Table
+####################################################
+Pod: webserver-bad-85cf9ccdf8-8v4mh
+PodIP: 10.42.0.252
+Port: 80
+Endpoint: ingress-1d8af467b8b7c9682fda18c8d5053db7
+Ingress: test-bad
+Ingress Pod: nginx-ingress-controller-b2s2d
+Node: a1ubphylbp01
+Status: Fail!
+####################################################
+```
+
+```
+bash ./check.sh -F Inline
+Checking Pod webserver-bad-8v4mh PodIP 10.42.0.252 on Port 80 in endpoint ingress-bad for ingress test-bad from nginx-ingress-controller-b2s2d on node a1ubphylbp01 NOK
+```
+
+### Working pod
+
+```
+bash ./check.sh -F Table
+####################################################
+Pod: webserver-bad-85cf9ccdf8-8v4mh
+PodIP: 10.42.0.252
+Port: 80
+Endpoint: ingress-1d8af467b8b7c9682fda18c8d5053db7
+Ingress: test-bad
+Ingress Pod: nginx-ingress-controller-b2s2d
+Node: a1ubphylbp01
+Status: Pass!
+####################################################
+```
+
+```
+bash ./check.sh -F Inline
+Checking Pod webserver-good-65644cffd4-gbpkj PodIP 10.42.0.251 on Port 80 in endpoint ingress-good for ingress test-good from nginx-ingress-controller-b2s2d on node a1ubphylbp01 OK
+```
+
+## Testing
+
+The following commands will deploy two workloads and ingresses. One that is working with a webserver that is responding on port 80. And the other will have the webserver disabled so it will fail to connect.
+
+```
+kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/master/NGINX-to-pods-check/example-deployment.yml
+```

--- a/NGINX-to-pods-check/README.md
+++ b/NGINX-to-pods-check/README.md
@@ -1,5 +1,5 @@
 # NGINX-to-pods-check
-This script is designed to walk through all the ingresses in a cluster and test that it can curl the backend pods from the NGINX pods. This is mainly done to verify the overlay network is working along with checking the overall configurtion.
+This script is designed to walk through all the ingresses in a cluster and test that it can curl the backend pods from the NGINX pods. This is mainly done to verify the overlay network is working along with checking the overall configuration.
 
 ## Run script
 ```

--- a/NGINX-to-pods-check/check.sh
+++ b/NGINX-to-pods-check/check.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+
+usage()
+{
+cat << EOF
+usage: $0 options
+OPTIONS:
+   -h      Show this message
+   -F      Format Default: Table
+EOF
+}
+
+VERBOSE=
+while getopts .h:F:v. OPTION
+do
+     case $OPTION in
+         h)
+             usage
+             exit 1
+             ;;
+         F)
+             FORMAT=$OPTARG
+             ;;
+         ?)
+             usage
+             exit
+             ;;
+     esac
+done
+
+if [[ -z $FORMAT ]]
+then
+        FORMAT="Table"
+fi
+
+if [[ ! "$FORMAT" == "Table" ]] && [[ ! "$FORMAT" == "Inline" ]]
+then
+	echo "Invalid Option for flag -F"
+	exit 1
+fi
+
+
+kubectl get namespace -o custom-columns=NAMESPACE:.metadata.name --no-headers | while read namespace
+do
+	kubectl get ingress -n "$namespace" -o custom-columns=ingress:.metadata.name --no-headers | while read ingress
+	do
+		kubectl get ingress $ingress -n $namespace -o yaml | grep 'serviceName: ' | awk '{print $2}' | sort | uniq | while read servicename
+		do
+			PORT="$(kubectl get endpoints "$servicename" -n "$namespace" -o yaml | grep 'port:' | awk '{print $2}')"
+			if [[ "$PORT" == 'port:' ]]
+			then
+				PORT="80"
+			fi
+			kubectl get endpoints "$servicename" -n "$namespace" -o yaml | grep '\- ip:' | awk '{print $3}' | while read endpointpodip
+			do
+				kubectl -n ingress-nginx get pods -l app=ingress-nginx -o custom-columns=POD:.metadata.name,NODE:.spec.nodeName,IP:.status.podIP --no-headers | while read ingresspod nodename podip
+				do
+					PODNAME="$(kubectl get pods -n $namespace -o custom-columns=POD:.metadata.name,IP:.status.podIP --no-headers | grep "$endpointpodip" | awk '{print $1}' | tr -d ' ')"
+					if ! kubectl -n ingress-nginx exec $ingresspod -- curl -o /dev/null --connect-timeout 5 -s -q http://${endpointpodip}:${PORT} &> /dev/null
+					then
+						if [[ "$FORMAT" == "Inline" ]]
+						then
+							tput setaf 7; echo -n "Checking Pod $PODNAME PodIP $endpointpodip on Port $PORT in endpoint $servicename for ingress $ingress from $ingresspod on node $nodename "; tput setaf 1; echo "NOK"; tput sgr0
+						fi
+						if [[ "$FORMAT" == "Table" ]]
+						then
+							echo "####################################################"
+							echo "Pod: $PODNAME"
+							echo "PodIP: $endpointpodip"
+							echo "Port: $PORT"
+							echo "Endpoint: $servicename"
+							echo "Ingress: $ingress"
+							echo "Ingress Pod: $ingresspod"
+							echo "Node: $nodename"
+							tput setaf 1;echo "Status: Fail!"; tput sgr0
+							echo "####################################################"
+						fi
+					else
+						if [[ "$FORMAT" == "Inline" ]]
+						then
+							tput setaf 7; echo -n "Checking Pod $PODNAME PodIP $endpointpodip on Port $PORT in endpoint $servicename for ingress $ingress from $ingresspod on node $nodename "; tput setaf 2; echo "OK"; tput sgr0
+						fi
+						if [[ "$FORMAT" == "Table" ]]
+                                                then
+                                                        echo "####################################################"
+                                                        echo "Pod: $PODNAME"
+                                                        echo "PodIP: $endpointpodip"
+                                                        echo "Port: $PORT"
+                                                        echo "Endpoint: $servicename"
+                                                        echo "Ingress: $ingress"
+                                                        echo "Ingress Pod: $ingresspod"
+                                                        echo "Node: $nodename"
+                                                        tput setaf 2;echo "Status: Pass!"; tput sgr0
+                                                        echo "####################################################"
+                                                fi
+					fi
+				done
+			done
+		done
+	done
+done
+

--- a/NGINX-to-pods-check/example-deployment.yml
+++ b/NGINX-to-pods-check/example-deployment.yml
@@ -1,0 +1,104 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: webserver-good
+  name: webserver-good
+spec:
+  selector:
+    matchLabels:
+      app: webserver-good
+  template:
+    metadata:
+      labels:
+        app: webserver-good
+    spec:
+      containers:
+      - name: webserver-good
+        image: httpd
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: webserver-bad
+  name: webserver-bad
+spec:
+  selector:
+    matchLabels:
+      app: webserver-bad
+  template:
+    metadata:
+      labels:
+        app: webserver-bad
+    spec:
+      containers:
+      - args:
+        - while true; do sleep 100000; done;
+        command:
+        - /bin/sh
+        - -c
+      - name: webserver-bad
+        image: httpd
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: webserver-good
+  name: webserver-good
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    targetPort: 80
+  selector:
+    app: webserver-good
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: webserver-bad
+  name: webserver-bad
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    targetPort: 80
+  selector:
+    app: webserver-bad
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: webserver-good
+spec:
+  rules:
+  - host: webserver-good.local
+    http:
+      paths:
+      - backend:
+          serviceName: webserver-good
+          servicePort: 80
+        path: /
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: webserver-bad
+spec:
+  rules:
+  - host: webserver-bad.local
+    http:
+      paths:
+      - backend:
+          serviceName: webserver-bad
+          servicePort: 80
+        path: /

--- a/NGINX-to-pods-check/example-deployment.yml
+++ b/NGINX-to-pods-check/example-deployment.yml
@@ -15,8 +15,8 @@ spec:
         app: webserver-good
     spec:
       containers:
-      - name: webserver-good
-        image: httpd
+      - image: httpd
+        name: webserver-good
 
 ---
 apiVersion: apps/v1
@@ -40,8 +40,9 @@ spec:
         command:
         - /bin/sh
         - -c
-      - name: webserver-bad
         image: httpd
+        imagePullPolicy: Always
+        name: webserver-bad
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This script is designed to walk through all the ingresses in a cluster and test that it can curl the backend pods from the NGINX pods. This is mainly done to verify the overlay network is working along with checking the overall configuration.

Importing from https://github.com/mattmattox/NGINX-to-pods-check