### PR TITLE
Remove unmount for kubelet and rancher

### DIFF
--- a/extended-rancher-2-cleanup/extended-cleanup-rancher2.sh
+++ b/extended-rancher-2-cleanup/extended-cleanup-rancher2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Directories to cleanup
-CLEANUP_DIRS=(/etc/ceph /etc/cni /etc/kubernetes /opt/cni /opt/rke /run/secrets/kubernetes.io /run/calico /run/flannel /var/lib/calico /var/lib/weave /var/lib/etcd /var/lib/cni /var/lib/kubelet /var/lib/rancher/rke/log /var/log/containers /var/log/pods /var/run/calico)
+CLEANUP_DIRS=(/etc/ceph /etc/cni /etc/kubernetes /opt/cni /opt/rke /run/secrets/kubernetes.io /run/calico /run/flannel /var/lib/calico /var/lib/weave /var/lib/etcd /var/lib/cni /var/lib/kubelet/* /var/lib/rancher/rke/log /var/log/containers /var/log/pods /var/run/calico)
 
 # Interfaces to cleanup
 CLEANUP_INTERFACES=(flannel.1 cni0 tunl0)

--- a/extended-rancher-2-cleanup/extended-cleanup-rancher2.sh
+++ b/extended-rancher-2-cleanup/extended-cleanup-rancher2.sh
@@ -52,7 +52,7 @@ cleanup-containers() {
 cleanup-dirs() {
 
   techo "Unmounting filesystems..."
-  for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }') /var/lib/kubelet /var/lib/rancher
+  for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }')
     do
       umount $mount
   done


### PR DESCRIPTION
These filesystems shouldn't be unmounted, tested on a downstream RKE node.

Previously would experience the below:
```
2021-03-24 23:06:41: Unmounting filesystems...
umount: /var/lib/kubelet: not mounted.
umount: /var/lib/rancher: not mounted.
```

In cases where these are actual filesystems this could cause `/var` to be used for k8s/docker/rancher.