### PR TITLE
Add lower nice and ionice priorities by default

### DIFF
--- a/collection/rancher/v2.x/logs-collector/README.md
+++ b/collection/rancher/v2.x/logs-collector/README.md
@@ -14,12 +14,13 @@ The script will create a .tar.gz log collection in /tmp by default, all flags ar
 
 ```
 Rancher 2.x logs-collector
-  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -f ]
+  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -p -f ]
 
   All flags are optional
 
   -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
   -s    Number of days history to collect from container and journald logs (ex: -s 7)
   -r    Override container runtime if not automatically detected (docker|k3s)
+  -p    When supplied runs with the default nice/ionice priorities, otherwise use the lowest priorities
   -f    Force log collection if the minimum space isn't available
 ```


### PR DESCRIPTION
Default nice/ionice to lowest priorities by default, override with `-p` to use the default priorities

Test on Ubuntu 20.04:

```bash
root@d-lab-w1:~# ps aux | grep logs.sh
root     3018969  0.2  0.1   9144  4132 pts/1    SN+  22:10   0:00 bash logs.sh
root     3019037  0.0  0.0   8164  2440 pts/0    SN+  22:10   0:00 grep --color=auto logs.sh
root@d-lab-w1:~# ionice -p 3018969
idle
root@d-lab-w1:~# ps -eo pid,ppid,ni,comm | grep 3018969
3018969 3002142  19 bash
3019095 3018969  19 bash
3019156 3018969  19 service
```