### PR TITLE
Fix temporary directory handling in logs collector

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -578,7 +578,7 @@ fi
 while getopts ":d:s:r:fph" opt; do
   case $opt in
     d)
-      MKTEMP_BASEDIR="-p ${OPTARG}"
+      MKTEMP_BASEDIR="${OPTARG}/temp.XXXX"
       ;;
     s)
       START=$(date -d "-${OPTARG} days" '+%Y-%m-%d')


### PR DESCRIPTION
Remove `-p` flag and use a pattern to allow use of an existing directory.