### PR TITLE
Add rke2 support to logs-collector

### DIFF
--- a/collection/rancher/v2.x/logs-collector/README.md
+++ b/collection/rancher/v2.x/logs-collector/README.md
@@ -14,13 +14,13 @@ The script will create a .tar.gz log collection in /tmp by default, all flags ar
 
 ```
 Rancher 2.x logs-collector
-  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -p -f ]
+  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <k8s distribution> -p -f ]
 
   All flags are optional
 
   -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
   -s    Number of days history to collect from container and journald logs (ex: -s 7)
-  -r    Override container runtime if not automatically detected (docker|k3s)
+  -r    Override k8s distribution if not automatically detected (rke|k3s|rke2)
   -p    When supplied runs with the default nice/ionice priorities, otherwise use the lowest priorities
   -f    Force log collection if the minimum space isn't available
 ```

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -63,35 +63,47 @@ sherlock() {
     else
       echo -e "\n$(timestamp): couldn't detect OS"
   fi
-  if [ -n "${RUNTIME_FLAG}" ]
+  if [ -n "${DISTRO_FLAG}" ]
     then
-      techo "Setting container runtime as ${RUNTIME_FLAG}"
-      RUNTIME="${RUNTIME_FLAG}"
+      techo "Setting k8s distro as ${DISTRO_FLAG}"
+      DISTRO="${DISTRO_FLAG}"
     else
-      echo -n "$(timestamp): Detecting container runtime... "
+      echo -n "$(timestamp): Detecting k8s distribution... "
       if $(command -v docker >/dev/null 2>&1)
         then
           if $(docker ps >/dev/null 2>&1)
             then
-              RUNTIME=docker
-              echo "docker"
+              DISTRO=rke
+              echo "rke"
             else
-              FOUND="docker "
+              FOUND="rke "
           fi
       fi
       if $(command -v k3s >/dev/null 2>&1)
         then
           if $(k3s crictl ps >/dev/null 2>&1)
             then
-              RUNTIME=k3s
+              DISTRO=k3s
               echo "k3s"
             else
               FOUND+="k3s"
           fi
       fi
-      if [ -z $RUNTIME ]
+      if $(command -v rke2 >/dev/null 2>&1)
         then
-          echo -e "\n$(timestamp): couldn't detect container runtime"
+          RKE2_BIN="/var/lib/rancher/rke2/bin"
+          CRI_CONFIG_FILE="/var/lib/rancher/rke2/agent/etc/crictl.yaml"
+          if $(${RKE2_BIN}/crictl ps >/dev/null 2>&1)
+            then
+              DISTRO=rke2
+              echo "rke2"
+            else
+              FOUND+="rke2"
+          fi
+      fi
+      if [ -z $DISTRO ]
+        then
+          echo -e "\n$(timestamp): couldn't detect k8s distro"
           if [ -n "${FOUND}" ]
             then
               techo "Found ${FOUND} but could not execute commands successfully"
@@ -247,7 +259,7 @@ networking() {
 
 }
 
-docker-logs() {
+rke-logs() {
 
   techo "Collecting docker info"
   mkdir -p $TMPDIR/docker
@@ -283,7 +295,30 @@ k3s-logs() {
 
 }
 
-docker-rancher() {
+rke2-logs() {
+
+  techo "Collecting rke2 info"
+  mkdir -p $TMPDIR/rke2/crictl
+  rke2 --version > $TMPDIR/rke2/version 2>&1
+  ${RKE2_BIN}/crictl --version > $TMPDIR/rke2/crictl/crictl-version 2>&1
+  ${RKE2_BIN}/containerd --version > $TMPDIR/rke2/crictl/containerd-version 2>&1
+  ${RKE2_BIN}/runc --version > $TMPDIR/rke2/crictl/runc-version 2>&1
+  ${RKE2_BIN}/crictl ps -a > $TMPDIR/rke2/crictl/psa 2>&1
+  ${RKE2_BIN}/crictl pods > $TMPDIR/rke2/crictl/pods 2>&1
+  ${RKE2_BIN}/crictl info > $TMPDIR/rke2/crictl/info 2>&1
+  ${RKE2_BIN}/crictl stats -a > $TMPDIR/rke2/crictl/statsa 2>&1
+  ${RKE2_BIN}/crictl version > $TMPDIR/rke2/crictl/version 2>&1
+  ${RKE2_BIN}/crictl images > $TMPDIR/rke2/crictl/images 2>&1
+  ${RKE2_BIN}/crictl imagefsinfo > $TMPDIR/rke2/crictl/imagefsinfo 2>&1
+  ${RKE2_BIN}/crictl stats -a > $TMPDIR/rke2/crictl/statsa 2>&1
+  if [ -f /usr/local/lib/systemd/system/rke2-agent.service ]
+    then
+      cp -p /usr/local/lib/systemd/system/rke2*.service $TMPDIR/rke2/
+  fi
+
+}
+
+rke-k8s() {
 
   techo "Collecting rancher logs"
   # Discover any server or agent running
@@ -341,7 +376,7 @@ docker-rancher() {
 
 }
 
-k3s-rancher() {
+k3s-k8s() {
 
   techo "Collecting k3s cluster logs"
   if [ -d /var/lib/rancher/k3s/agent ]; then
@@ -368,7 +403,7 @@ k3s-rancher() {
   fi
 
   mkdir -p $TMPDIR/k3s/podlogs
-  techo "Collecting Rancher logs"
+  techo "Collecting system pod logs"
   if [ -d /var/lib/rancher/k3s/server ]; then
     for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
       for SYSTEM_POD in $(k3s kubectl -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
@@ -380,6 +415,52 @@ k3s-rancher() {
     for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
       if ls -d /var/log/pods/$SYSTEM_NAMESPACE* > /dev/null 2>&1; then
         cp -r -p /var/log/pods/$SYSTEM_NAMESPACE* $TMPDIR/k3s/podlogs/
+      fi
+    done
+  fi
+
+}
+
+rke2-k8s() {
+
+  techo "Collecting rke2 cluster logs"
+  if [ -f /var/lib/rancher/rke2/agent/kubelet.kubeconfig ]; then
+    mkdir -p $TMPDIR/rke2/kubectl
+    KUBECONFIG=/var/lib/rancher/rke2/agent/kubelet.kubeconfig
+    ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG get nodes -o wide > $TMPDIR/rke2/kubectl/nodes 2>&1
+    ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG describe nodes > $TMPDIR/rke2/kubectl/nodesdescribe 2>&1
+    ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG version > $TMPDIR/rke2/kubectl/version 2>&1
+    ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG get pods -o wide --all-namespaces > $TMPDIR/rke2/kubectl/pods 2>&1
+    ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG get svc -o wide --all-namespaces > $TMPDIR/rke2/kubectl/services 2>&1
+  fi
+
+  if [ -f /etc/rancher/rke2/rke2.yaml ]; then
+    KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+    ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG api-resources > $TMPDIR/rke2/kubectl/api-resources 2>&1
+    RKE2_OBJECTS=(clusterroles clusterrolebindings crds mutatingwebhookconfigurations namespaces nodes pv validatingwebhookconfigurations)
+    RKE2_OBJECTS_NAMESPACED=(apiservices configmaps cronjobs deployments daemonsets endpoints events helmcharts hpa ingress jobs leases pods pvc replicasets roles rolebindings statefulsets)
+    for OBJECT in "${RKE2_OBJECTS[@]}"; do
+      ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG get ${OBJECT} -o wide > $TMPDIR/rke2/kubectl/${OBJECT} 2>&1
+    done
+    for OBJECT in "${RKE2_OBJECTS_NAMESPACED[@]}"; do
+      ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG get ${OBJECT} --all-namespaces -o wide > $TMPDIR/rke2/kubectl/${OBJECT} 2>&1
+    done
+  fi
+
+  mkdir -p $TMPDIR/rke2/podlogs
+  techo "Collecting system pod logs"
+  if [ -f /etc/rancher/rke2/rke2.yaml ]; then
+    KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+    for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
+      for SYSTEM_POD in $(${RKE2_BIN}/kubectl -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
+        ${RKE2_BIN}/kubectl -n $SYSTEM_NAMESPACE logs --all-containers $SYSTEM_POD > $TMPDIR/rke2/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD 2>&1
+        ${RKE2_BIN}/kubectl -n $SYSTEM_NAMESPACE logs -p --all-containers $SYSTEM_POD > $TMPDIR/rke2/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD-previous 2>&1
+      done
+    done
+  elif [ -f /var/lib/rancher/rke2/agent/kubelet.kubeconfig ]; then
+    for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
+      if ls -d /var/log/pods/$SYSTEM_NAMESPACE* > /dev/null 2>&1; then
+        cp -r -p /var/log/pods/$SYSTEM_NAMESPACE* $TMPDIR/rke2/podlogs/
       fi
     done
   fi
@@ -453,19 +534,17 @@ k3s-certs() {
     then
       techo "Collecting k3s directory state"
       mkdir -p $TMPDIR/k3s/directories
-      if [ -d /var/lib/rancher/k3s ]; then
-        ls -lah /var/lib/rancher/k3s/agent > $TMPDIR/k3s/directories/k3sagent 2>&1
-        ls -lah /var/lib/rancher/k3s/server/manifests > $TMPDIR/k3s/directories/k3sservermanifests 2>&1
-        ls -lah /var/lib/rancher/k3s/server/tls > $TMPDIR/k3s/directories/k3sservertls 2>&1
-      fi
+      ls -lah /var/lib/rancher/k3s/agent > $TMPDIR/k3s/directories/k3sagent 2>&1
+      ls -lah /var/lib/rancher/k3s/server/manifests > $TMPDIR/k3s/directories/k3sservermanifests 2>&1
+      ls -lah /var/lib/rancher/k3s/server/tls > $TMPDIR/k3s/directories/k3sservertls 2>&1
       techo "Collecting k3s certificates"
-      mkdir -p {$TMPDIR/k3s/certs/agent,$TMPDIR/k3s/certs/server}
+      mkdir -p $TMPDIR/k3s/certs/{agent,server}
       AGENT_CERTS=$(find /var/lib/rancher/k3s/agent -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")
       for CERT in $AGENT_CERTS
         do
           openssl x509 -in $CERT -text -noout > $TMPDIR/k3s/certs/agent/$(basename $CERT) 2>&1
       done
-      if [ -d /var/lib/rancher/k3s/server ]; then
+      if [ -d /var/lib/rancher/k3s/server/tls ]; then
         techo "Collecting k3s Server certificates"
         SERVER_CERTS=$(find /var/lib/rancher/k3s/server/tls -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")
         for CERT in $SERVER_CERTS
@@ -477,9 +556,37 @@ k3s-certs() {
 
 }
 
-etcd() {
+rke2-certs() {
 
-  techo "Collecting etcd info"
+  if [ -d /var/lib/rancher/rke2 ]
+    then
+      techo "Collecting rke2 directory state"
+      mkdir -p $TMPDIR/rke2/directories
+      ls -lah /var/lib/rancher/rke2/agent > $TMPDIR/rke2/directories/rke2agent 2>&1
+      ls -lah /var/lib/rancher/rke2/server/manifests > $TMPDIR/rke2/directories/rke2servermanifests 2>&1
+      ls -lah /var/lib/rancher/rke2/server/tls > $TMPDIR/rke2/directories/rke2servertls 2>&1
+      techo "Collecting rke2 certificates"
+      mkdir -p $TMPDIR/rke2/certs/{agent,server}
+      AGENT_CERTS=$(find /var/lib/rancher/rke2/agent -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")
+      for CERT in $AGENT_CERTS
+        do
+          openssl x509 -in $CERT -text -noout > $TMPDIR/rke2/certs/agent/$(basename $CERT) 2>&1
+      done
+      if [ -d /var/lib/rancher/rke2/server/tls ]; then
+        techo "Collecting rke2 Server certificates"
+        SERVER_CERTS=$(find /var/lib/rancher/rke2/server/tls -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")
+        for CERT in $SERVER_CERTS
+          do
+            openssl x509 -in $CERT -text -noout > $TMPDIR/rke2/certs/server/$(basename $CERT) 2>&1
+        done
+      fi
+  fi
+
+}
+
+rke-etcd() {
+
+  techo "Collecting rke etcd info"
   mkdir -p $TMPDIR/etcd
   if [ -d /var/lib/etcd ]; then
     find /var/lib/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findvarlibetcd 2>&1
@@ -487,9 +594,8 @@ etcd() {
     find /opt/rke/var/lib/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkevarlibetcd 2>&1
   fi
 
-  # /opt/rke contents
   if [ -d /opt/rke/etcd-snapshots ]; then
-    find /opt/rke/etcd-snapshots -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkeetcdsnaphots 2>&1
+    find /opt/rke/etcd-snapshots -type f -exec ls -la {} \; > $TMPDIR/etcd/findoptrkeetcdsnapshots 2>&1
   fi
 
   if docker ps --format='{{.Names}}' | grep -q ^etcd$ >/dev/null 2>&1; then
@@ -507,6 +613,27 @@ etcd() {
     docker exec -e ETCDCTL_ENDPOINTS=$(docker exec etcd /bin/sh -c "etcdctl $PARAM member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','") etcd etcdctl endpoint status --write-out table > $TMPDIR/etcd/endpointstatus 2>&1
     docker exec -e ETCDCTL_ENDPOINTS=$(docker exec etcd /bin/sh -c "etcdctl $PARAM member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','") etcd etcdctl endpoint health > $TMPDIR/etcd/endpointhealth 2>&1
     docker exec etcd sh -c "etcdctl $PARAM alarm list" > $TMPDIR/etcd/alarmlist 2>&1
+  fi
+
+}
+
+rke2-etcd() {
+
+  RKE2_ETCD=$(${RKE2_BIN}/crictl ps --quiet --label io.kubernetes.container.name=etcd --state running)
+  if [ ! -z ${RKE2_ETCD} ]; then
+    techo "Collecting rke2 etcd info"
+    mkdir -p $TMPDIR/etcd
+    ETCDCTL_ENDPOINTS=$(${RKE2_BIN}/crictl exec ${RKE2_ETCD} /bin/sh -c "etcdctl --cert /var/lib/rancher/rke2/server/tls/etcd/server-client.crt --key /var/lib/rancher/rke2/server/tls/etcd/server-client.key --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt member list | cut -d, -f5 | sed -e 's/ //g' | paste -sd ','")
+    ${RKE2_BIN}/crictl exec ${RKE2_ETCD} /bin/sh -c "ETCDCTL_ENDPOINTS=$ETCDCTL_ENDPOINTS etcdctl --cert /var/lib/rancher/rke2/server/tls/etcd/server-client.crt --key /var/lib/rancher/rke2/server/tls/etcd/server-client.key --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt --write-out table endpoint status" > $TMPDIR/etcd/endpointstatus 2>&1
+    ${RKE2_BIN}/crictl exec ${RKE2_ETCD} /bin/sh -c "ETCDCTL_ENDPOINTS=$ETCDCTL_ENDPOINTS etcdctl --cert /var/lib/rancher/rke2/server/tls/etcd/server-client.crt --key /var/lib/rancher/rke2/server/tls/etcd/server-client.key --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt endpoint health" > $TMPDIR/etcd/endpointhealth 2>&1
+    ${RKE2_BIN}/crictl exec ${RKE2_ETCD} /bin/sh -c "ETCDCTL_ENDPOINTS=$ETCDCTL_ENDPOINTS etcdctl --cert /var/lib/rancher/rke2/server/tls/etcd/server-client.crt --key /var/lib/rancher/rke2/server/tls/etcd/server-client.key --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt alarm list" > $TMPDIR/etcd/alarmlist 2>&1
+  fi
+
+  if [ -d /var/lib/rancher/rke2/server/db/etcd ]; then
+    find /var/lib/rancher/rke2/server/db/etcd -type f -exec ls -la {} \; > $TMPDIR/etcd/findserverdbetcd 2>&1
+  fi
+  if [ -d /var/lib/rancher/rke2/server/db/snapshots ]; then
+    find /var/lib/rancher/rke2/server/db/snapshots -type f -exec ls -la {} \; > $TMPDIR/etcd/findserverdbsnapshots 2>&1
   fi
 
 }
@@ -544,13 +671,13 @@ cleanup() {
 help() {
 
   echo "Rancher 2.x logs-collector
-  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <container runtime> -p -f ]
+  Usage: rancher2_logs_collector.sh [ -d <directory> -s <days> -r <k8s distribution> -p -f ]
 
   All flags are optional
 
   -d    Output directory for temporary storage and .tar.gz archive (ex: -d /var/tmp)
   -s    Number of days history to collect from container and journald logs (ex: -s 7)
-  -r    Override container runtime if not automatically detected (docker|k3s)
+  -r    Override k8s distribution if not automatically detected (rke|k3s|rke2)
   -p    When supplied runs with the default nice/ionice priorities, otherwise use the lowest priorities
   -f    Force log collection if the minimum space isn't available"
 
@@ -585,7 +712,7 @@ while getopts ":d:s:r:fph" opt; do
       SINCE_FLAG="--since ${START}"
       ;;
     r)
-      RUNTIME_FLAG="${OPTARG}"
+      DISTRO_FLAG="${OPTARG}"
       ;;
     f)
       FORCE=1
@@ -628,17 +755,23 @@ elif [ "${OSRELEASE}" = "ubuntu" ]
   then
     system-ubuntu
 fi
-if [ "${RUNTIME}" = "docker" ]
+if [ "${DISTRO}" = "rke" ]
   then
-    docker-logs
-    docker-rancher
+    rke-logs
+    rke-k8s
     rke-certs
-    etcd
-elif [ "${RUNTIME}" = "k3s" ]
+    rke-etcd
+elif [ "${DISTRO}" = "k3s" ]
   then
     k3s-logs
-    k3s-rancher
+    k3s-k8s
     k3s-certs
+elif [ "${DISTRO}" = "rke2" ]
+  then
+    rke2-logs
+    rke2-k8s
+    rke2-certs
+    rke2-etcd
 fi
 var-log
 if [ "${INIT}" = "systemd" ]

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -92,7 +92,7 @@ sherlock() {
       if $(command -v rke2 >/dev/null 2>&1)
         then
           RKE2_BIN="/var/lib/rancher/rke2/bin"
-          CRI_CONFIG_FILE="/var/lib/rancher/rke2/agent/etc/crictl.yaml"
+          export CRI_CONFIG_FILE="/var/lib/rancher/rke2/agent/etc/crictl.yaml"
           if $(${RKE2_BIN}/crictl ps >/dev/null 2>&1)
             then
               DISTRO=rke2
@@ -452,9 +452,9 @@ rke2-k8s() {
   if [ -f /etc/rancher/rke2/rke2.yaml ]; then
     KUBECONFIG=/etc/rancher/rke2/rke2.yaml
     for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
-      for SYSTEM_POD in $(${RKE2_BIN}/kubectl -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
-        ${RKE2_BIN}/kubectl -n $SYSTEM_NAMESPACE logs --all-containers $SYSTEM_POD > $TMPDIR/rke2/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD 2>&1
-        ${RKE2_BIN}/kubectl -n $SYSTEM_NAMESPACE logs -p --all-containers $SYSTEM_POD > $TMPDIR/rke2/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD-previous 2>&1
+      for SYSTEM_POD in $(${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
+        ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE logs --all-containers $SYSTEM_POD > $TMPDIR/rke2/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD 2>&1
+        ${RKE2_BIN}/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE logs -p --all-containers $SYSTEM_POD > $TMPDIR/rke2/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD-previous 2>&1
       done
     done
   elif [ -f /var/lib/rancher/rke2/agent/kubelet.kubeconfig ]; then

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -545,7 +545,7 @@ k3s-certs() {
           openssl x509 -in $CERT -text -noout > $TMPDIR/k3s/certs/agent/$(basename $CERT) 2>&1
       done
       if [ -d /var/lib/rancher/k3s/server/tls ]; then
-        techo "Collecting k3s Server certificates"
+        techo "Collecting k3s server certificates"
         SERVER_CERTS=$(find /var/lib/rancher/k3s/server/tls -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")
         for CERT in $SERVER_CERTS
           do
@@ -573,7 +573,7 @@ rke2-certs() {
           openssl x509 -in $CERT -text -noout > $TMPDIR/rke2/certs/agent/$(basename $CERT) 2>&1
       done
       if [ -d /var/lib/rancher/rke2/server/tls ]; then
-        techo "Collecting rke2 Server certificates"
+        techo "Collecting rke2 server certificates"
         SERVER_CERTS=$(find /var/lib/rancher/rke2/server/tls -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")
         for CERT in $SERVER_CERTS
           do

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -9,7 +9,7 @@ SYSTEM_NAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-
 KUBE_CONTAINERS=(etcd etcd-rolling-snapshots kube-apiserver kube-controller-manager kubelet kube-scheduler kube-proxy nginx-proxy)
 
 # Included journald logs
-JOURNALD_LOGS=(docker k3s containerd cloud-init systemd-network kubelet kubeproxy)
+JOURNALD_LOGS=(docker k3s rke2-agent rke2-server containerd cloud-init systemd-network kubelet kubeproxy)
 
 # Minimum space needed to run the script (MB)
 SPACE=1536


### PR DESCRIPTION
Added rke2 detection and collection, small general updates for consistency

Updated wording for 'runtime' to 'distribution' as this seemed more relevant (k3s/rke2 both use containerd etc). Tests so far have been done on Ubuntu 20.04.

- [x] Test on RKE2 server/agent
- [x] Test on RKE control plane node
- [x] Test on RKE worker node
- [ ] Test on k3s server/agent