### PR TITLE
Add ip link show to get dropped packets, etc. stats

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -237,6 +237,7 @@ networking() {
     ip addr show > $TMPDIR/networking/ipaddrshow 2>&1
     ip route show table all > $TMPDIR/networking/iproute 2>&1
     ip rule show > $TMPDIR/networking/iprule 2>&1
+    ip -s link show > $TMPDIR/networking/iplinkshow 2>&1
   fi
   if $(command -v ifconfig >/dev/null 2>&1); then
     ifconfig -a > $TMPDIR/networking/ifconfiga


### PR DESCRIPTION
When ifconfig is not installed, we don't get error, dropped, overrun, etc. information. This adds the equivalent ip command to gather those stats.