### PR TITLE
Add pod name to RKE Rancher Agent lookup in log collector

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -325,7 +325,7 @@ rke-k8s() {
   # Discover any server or agent running
   mkdir -p $TMPDIR/rancher/{containerlogs,containerinspect}
   RANCHERSERVERS=$(docker ps -a | grep -E "k8s_rancher_rancher|rancher/rancher:|rancher/rancher " | awk '{ print $1 }')
-  RANCHERAGENTS=$(docker ps -a | grep -E "rancher/rancher-agent:|rancher/rancher-agent " | awk '{ print $1 }')
+  RANCHERAGENTS=$(docker ps -a | grep -E "k8s_agent_cattle|rancher/rancher-agent:|rancher/rancher-agent " | awk '{ print $1 }')
 
   for RANCHERSERVER in $RANCHERSERVERS; do
     docker inspect $RANCHERSERVER > $TMPDIR/rancher/containerinspect/server-$RANCHERSERVER 2>&1


### PR DESCRIPTION
Some airgapped client instances don't tag images, which causes Rancher Agent logs to not be collected. Added partial name to the grep for Rancher Agent to allow matching beyond "just" image tags.  Example docker ps -a output of agent that wouldn't be matched previously:

c1325a715fc3        911263d98471                                                                     "run.sh"                 6 days ago          Up 6 days                                     k8s_agent_cattle-node-agent-mn92x_cattle-system_2818e8e0-3706-44b8-a787-41ff3e7aa8c1_0