### PR TITLE
Add ip6tables gathering

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -210,6 +210,7 @@ networking() {
   techo "Collecting network info"
   mkdir -p $TMPDIR/networking
   iptables-save > $TMPDIR/networking/iptablessave 2>&1
+  ip6tables-save > $TMPDIR/networking/iptablessave 2>&1
   if [ ! "${OSRELEASE}" = "sles" ]
     then
       IPTABLES_FLAGS="--wait 1"
@@ -217,6 +218,9 @@ networking() {
   iptables $IPTABLES_FLAGS --numeric --verbose --list --table mangle > $TMPDIR/networking/iptablesmangle 2>&1
   iptables $IPTABLES_FLAGS --numeric --verbose --list --table nat > $TMPDIR/networking/iptablesnat 2>&1
   iptables $IPTABLES_FLAGS --numeric --verbose --list > $TMPDIR/networking/iptables 2>&1
+  ip6tables $IPTABLES_FLAGS --numeric --verbose --list --table mangle > $TMPDIR/networking/iptablesmangle 2>&1
+  ip6tables $IPTABLES_FLAGS --numeric --verbose --list --table nat > $TMPDIR/networking/iptablesnat 2>&1
+  ip6tables $IPTABLES_FLAGS --numeric --verbose --list > $TMPDIR/networking/iptables 2>&1
   if $(command -v netstat >/dev/null 2>&1); then
     if [ "${OSRELEASE}" = "rancheros" ]
       then


### PR DESCRIPTION
With Kubernetes supporting dual stack, and some clients using dual stack, it is worth also gathering the ip6tables information as well. Useful for debugging.