### PR TITLE
Add new Rancher 2.6 fleet namespaces to the log collector

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -3,7 +3,7 @@
 # https://rancher.com/support-maintenance-terms#rancher-support-matrix
 
 # Included namespaces
-SYSTEM_NAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-logging cattle-pipeline ingress-nginx cattle-prometheus istio-system longhorn-system cattle-global-data fleet-system fleet-default rancher-operator-system cattle-monitoring-system cattle-logging-system)
+SYSTEM_NAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-logging cattle-pipeline ingress-nginx cattle-prometheus istio-system longhorn-system cattle-global-data fleet-system fleet-default rancher-operator-system cattle-monitoring-system cattle-logging-system cattle-fleet-system cattle-fleet-local-system)
 
 # Included container logs
 KUBE_CONTAINERS=(etcd etcd-rolling-snapshots kube-apiserver kube-controller-manager kubelet kube-scheduler kube-proxy nginx-proxy)


### PR DESCRIPTION
There are new fleet namespaces included as part of the 2.6 release, cattle-fleet-system and cattle-fleet-local-system, that may need also to be captured during the log collecting process.