### PR TITLE
Loop all resources in known namespaces

### DIFF
--- a/cleanup-rancher-k8s-resources/cleanup.sh
+++ b/cleanup-rancher-k8s-resources/cleanup.sh
@@ -302,31 +302,48 @@ for NS in $(kubectl  get ns --no-headers -o custom-columns=NAME:.metadata.name);
 done
 
 # Delete all cattle namespaces, including project namespaces (p-),cluster (c-),cluster-fleet and user (user-) namespaces
-for NS in $TOOLS_NAMESPACES; do
-  kcdns $NS
-done
+for NS in $TOOLS_NAMESPACES $FLEET_NAMESPACES $CATTLE_NAMESPACES; do
+  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
+    kcpf -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+    kcd -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+  done
 
-for NS in $FLEET_NAMESPACES; do
-  kcdns $NS
-done
-
-for NS in $CATTLE_NAMESPACES; do
   kcdns $NS
 done
 
 for NS in $(kubectl get namespace --no-headers -o custom-columns=NAME:.metadata.name | grep "^cluster-fleet"); do
+  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| grep -v events\.events\.k8s\.io | grep -v ^events$ | tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
+    kcpf -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+    kcd -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+  done
+
   kcdns $NS
 done
 
 for NS in $(kubectl get namespace --no-headers -o custom-columns=NAME:.metadata.name | grep "^p-"); do
+  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| grep -v events\.events\.k8s\.io | grep -v ^events$ | tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
+    kcpf -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+    kcd -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+  done
+
   kcdns $NS
 done
 
 for NS in $(kubectl get namespace --no-headers -o custom-columns=NAME:.metadata.name | grep "^c-"); do
+  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| grep -v events\.events\.k8s\.io | grep -v ^events$ | tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
+    kcpf -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+    kcd -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+  done
+
   kcdns $NS
 done
 
 for NS in $(kubectl get namespace --no-headers -o custom-columns=NAME:.metadata.name | grep "^user-"); do
+  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| grep -v events\.events\.k8s\.io | grep -v ^events$ | tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
+    kcpf -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+    kcd -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
+  done
+
   kcdns $NS
 done
 

--- a/cleanup-rancher-k8s-resources/cleanup.sh
+++ b/cleanup-rancher-k8s-resources/cleanup.sh
@@ -74,6 +74,7 @@ CATTLE_DATA_NAMESPACES="cattle-global-data cattle-global-nt"
 
 # Delete rancher install to not have anything running that (re)creates resources
 kcd -n cattle-system deploy,ds --all
+kubectl -n cattle-system wait --for delete pod --selector=app=rancher
 # Delete the only resource not in cattle namespaces
 kcd -n kube-system configmap cattle-controllers
 

--- a/cleanup-rancher-k8s-resources/verify.sh
+++ b/cleanup-rancher-k8s-resources/verify.sh
@@ -67,6 +67,7 @@ kcg namespace -o name | grep "cis-operator-system"
 kcg namespace -o name | grep "^c-"
 kcg namespace -o name | grep "^p-"
 kcg namespace -o name | grep "^user-"
+kcg namespace -o name | grep "^u-"
 kcg namespace -o name | grep "fleet"
 kcg namespace -o name | grep "istio"
 


### PR DESCRIPTION
* This removes all resources in known namespaces so namespace removal does not get stuck on remaining resources in that namespace
* Also adds 2.5.x fleet namespace `fleet-system`