### PR TITLE
Exclude events from cleanup

### DIFF
--- a/cleanup-rancher-k8s-resources/cleanup.sh
+++ b/cleanup-rancher-k8s-resources/cleanup.sh
@@ -304,7 +304,7 @@ done
 
 # Delete all cattle namespaces, including project namespaces (p-),cluster (c-),cluster-fleet and user (user-) namespaces
 for NS in $TOOLS_NAMESPACES $FLEET_NAMESPACES $CATTLE_NAMESPACES; do
-  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
+  kubectl get $(kubectl api-resources --namespaced=true --verbs=delete -o name| grep -v events\.events\.k8s\.io | grep -v ^events$ | tr "\n" "," | sed -e 's/,$//') -n $NS --no-headers -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind,APIVERSION:.apiVersion | while read NAME NAMESPACE KIND APIVERSION; do
     kcpf -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
     kcd -n $NAMESPACE "${KIND}.$(printapiversion $APIVERSION)" $NAME
   done


### PR DESCRIPTION
As there can be a lot of events, it is unnecessary to loop through all and delete them one-by-one as the namespace deletion will delete all of them.