### PR TITLE
Pin Ubuntu images until tested

### DIFF
--- a/bad-ingress-scanner/Dockerfile
+++ b/bad-ingress-scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 MAINTAINER Matthew Mattox <matt.mattox@suse.com>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/change-nodetemplate-owner/Dockerfile
+++ b/change-nodetemplate-owner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 MAINTAINER patrick0057
 ENV TERM xterm
 RUN apt-get update && apt-get install -y apt-transport-https curl gnupg2 && \


### PR DESCRIPTION
The tag `latest` switched to `22.04` and it might be failing because of that, and it's not tested so better to pin and move over when it's tested/validated.