### PR TITLE
Adding swiss-army-knife deployments

### DIFF
--- a/swiss-army-knife/README.md
+++ b/swiss-army-knife/README.md
@@ -1,0 +1,38 @@
+# Swiss-Army-Knife
+Rancher Support uses the image of a standard tool called `swiss-army-knife` to help you manage your Rancher/Kubernetes environment. You can learn more about this image by visiting its official repo at [rancherlabs/swiss-army-knife](https://github.com/rancherlabs/swiss-army-knife/)
+
+TLDR; This image has a lot of useful tools that can be used for scripting and troubleshooting.
+- [`kubectl`](https://kubernetes.io/docs/reference/kubectl/overview/)
+- [`helm`](https://helm.sh/docs/intro/)
+- [`curl`](https://curl.haxx.se/docs/manpage.html)
+- [`jq`](https://stedolan.github.io/jq/)
+- [`traceroute`](https://www.traceroute.org/about.html)
+- [`dig`](https://www.dig.com/products/dns/dig/)
+- [`nslookup`](https://www.google.com/search?q=nslookup)
+- [`ping`](https://www.google.com/search?q=ping)
+- [`netstat`](https://www.google.com/search?q=netstat)
+- And many more!
+
+## Example deployments
+
+### Overlay Test
+As part of Rancher's overlay test, which can be found [here](https://rancher.com/docs/rancher/v2.6/en/troubleshooting/networking/). You can be deployed to the Rancher environment by running the following command:
+```
+kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/deploy/overlaytest.yaml
+```
+
+This will deploy a deamonset that will run on all nodes in the cluster. These pods will be running `tail -f /dev/null,` which will do nothing but keep the pod running.
+
+### Admin Tools
+This deployment will deploy `swiss-army-knife` to all nodes in the cluster but with additional permissions and privileges. This is useful for troubleshooting and managing your Rancher environment. The pod will be running `tail -f /dev/null,` which will do nothing but keep the pod running.
+
+Inside the pod, you will be able to un `kubectl` commands with cluster-admin privileges. Along with this pod being able to gain full access to the node, including the ability to gain a root shell on the node. By running the following commands:
+- `kubectl -n kube-system get pods -l app=swiss-army-knife -o wide`
+- This will show you all pods running `swiss-army-knife` in the `kube-system` namespace.
+- Find the pod on the node you want to interact with.
+- `kubectl -n Kube-system exec -it <pod-name> -- bash`
+- `chroot /rootfs`
+
+You are now running a root shell on the node with full privileges.
+
+**Important:** This deployment is designed for troubleshooting and management purposes and should not be left running on a cluster.

--- a/swiss-army-knife/README.md
+++ b/swiss-army-knife/README.md
@@ -23,6 +23,11 @@ kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/mas
 
 This will deploy a deamonset that will run on all nodes in the cluster. These pods will be running `tail -f /dev/null,` which will do nothing but keep the pod running.
 
+You can run the overlay test script by running the following command:
+```
+curl -sfL https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/overlaytest.sh | bash
+```
+
 ### Admin Tools
 This deployment will deploy `swiss-army-knife` to all nodes in the cluster but with additional permissions and privileges. This is useful for troubleshooting and managing your Rancher environment. The pod will be running `tail -f /dev/null,` which will do nothing but keep the pod running.
 

--- a/swiss-army-knife/README.md
+++ b/swiss-army-knife/README.md
@@ -30,7 +30,7 @@ Inside the pod, you will be able to un `kubectl` commands with cluster-admin pri
 - `kubectl -n kube-system get pods -l app=swiss-army-knife -o wide`
 - This will show you all pods running `swiss-army-knife` in the `kube-system` namespace.
 - Find the pod on the node you want to interact with.
-- `kubectl -n Kube-system exec -it <pod-name> -- bash`
+- `kubectl -n kube-system exec -it <pod-name> -- bash`
 - `chroot /rootfs`
 
 You are now running a root shell on the node with full privileges.

--- a/swiss-army-knife/admin-tools.yaml
+++ b/swiss-army-knife/admin-tools.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: swiss-army-knife
+  name: swiss-army-knife
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: swiss-army-knife
+  namespace: kube-system
+  labels:
+    app: swiss-army-knife
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: swiss-army-knife
+  name: swiss-army-knife
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: swiss-army-knife
+subjects:
+- kind: ServiceAccount
+  name: swiss-army-knife
+  namespace: kube-system
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: swiss-army-knife
+  namespace: kube-system
+  labels:
+    app: swiss-army-knife
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: swiss-army-knife
+  name: swiss-army-knife-psp
+  namespace: kube-system
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - swiss-army-knife
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: swiss-army-knife-psp-binding
+  labels:
+    app: swiss-army-knife
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: swiss-army-knife-psp
+subjects:
+- kind: ServiceAccount
+  name: swiss-army-knife
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: swiss-army-knife
+  namespace: kube-system
+  labels:
+    app: swiss-army-knife
+spec:
+  selector:
+    matchLabels:
+      name: swiss-army-knife
+  template:
+    metadata:
+      labels:
+        name: swiss-army-knife
+    spec:
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: swiss-army-knife
+        image: supporttools/swiss-army-knife
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true        
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName            
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+      serviceAccountName: swiss-army-knife         
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /

--- a/swiss-army-knife/overlaytest.sh
+++ b/swiss-army-knife/overlaytest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "=> Start network overlay test"
+  kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.metadata.name}{" "}{@.spec.nodeName}{"\n"}{end}' |
+  while read spod shost 
+    do kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.status.podIP}{" "}{@.spec.nodeName}{"\n"}{end}' |
+    while read tip thost
+      do kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "ping -c2 $tip > /dev/null 2>&1"
+        RC=$?
+        if [ $RC -ne 0 ]
+          then echo FAIL: $spod on $shost cannot reach pod IP $tip on $thost
+          else echo $shost can reach $thost
+        fi
+    done
+  done
+echo "=> End network overlay test"

--- a/swiss-army-knife/overlaytest.yaml
+++ b/swiss-army-knife/overlaytest.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: overlaytest
+spec:
+  selector:
+      matchLabels:
+        name: overlaytest
+  template:
+    metadata:
+      labels:
+        name: overlaytest
+    spec:
+      tolerations:
+      - operator: Exists
+      containers:
+      - image: rancherlabs/swiss-army-knife
+        imagePullPolicy: IfNotPresent
+        name: overlaytest
+        command: ["sh", "-c", "tail -f /dev/null"]
+        terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
This PR adds some example deployments for swiss-army-knife with the two deployments being:
- Overlay test which is our standard overlaytest DaemonSet. This allows you to run `kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/deploy/overlaytest.yaml` instead of manually creating the file.
- Admin Tools which is an expansion of overlaytest but includes assigning cluster-admin permissions to the pod, runs the pods as privileged, moves the workload to kube-system (trying to avoid getting blocked by OPA), and mounts `/` on the host to `/rootfs` inside the pod to allow you to gain access to the node.