### PR TITLE
Created rancher-resource-enumerator script

### DIFF
--- a/rancher-crd/enumerate-resources/README.md
+++ b/rancher-crd/enumerate-resources/README.md
@@ -1,0 +1,25 @@
+# rancher-enumerate-resources
+
+Rancher Custom Resource enumeration script
+
+## Dependencies
+
+* `kubectl`
+* Linux, MacOS or WSL2
+
+## How to use
+
+* Download the script and save as: `rancher-resource-enumerator.sh`
+* Make sure the script is executable: `chmod u+x ./rancher-resource-enumerator.sh`
+* Run the script: `./rancher-resource-enumerator.sh`
+
+The script will output all Rancher custom resource data in the `/tmp/enum-cattle-resources-<timestamp>` directory by default. The `totals` file will give the total count for all resources.
+
+## Flags
+
+```
+Rancher Resource Enumerator
+Usage: ./rancher-resource-enumerator.sh [ -d <directory> ]
+ -h                               Display this help message.
+ -p <directory>                   Path to output directory (default: /tmp/enum-cattle-resources-<timestamp>).
+```

--- a/rancher-crd/enumerate-resources/README.md
+++ b/rancher-crd/enumerate-resources/README.md
@@ -1,4 +1,4 @@
-# rancher-enumerate-resources
+# rancher-resource-enumerator
 
 Rancher Custom Resource enumeration script
 

--- a/rancher-crd/enumerate-resources/README.md
+++ b/rancher-crd/enumerate-resources/README.md
@@ -11,7 +11,7 @@ Rancher Custom Resource enumeration script
 
 * Download the script and save as: `rancher-resource-enumerator.sh`
 * Make sure the script is executable: `chmod u+x ./rancher-resource-enumerator.sh`
-* Run the script: `./rancher-resource-enumerator.sh`
+* Run the script: `./rancher-resource-enumerator.sh -a`
 
 The script will output all Rancher custom resource data in the `/tmp/enum-cattle-resources-<timestamp>` directory by default. The `totals` file will give the total count for all resources.
 
@@ -19,7 +19,10 @@ The script will output all Rancher custom resource data in the `/tmp/enum-cattle
 
 ```
 Rancher Resource Enumerator
-Usage: ./rancher-resource-enumerator.sh [ -d <directory> ]
+Usage: ./rancher-resource-enumerator.sh [ -d <directory> -n <namespace> | -c | -a ]
  -h                               Display this help message.
- -p <directory>                   Path to output directory (default: /tmp/enum-cattle-resources-<timestamp>).
+ -a                               Enumerate all custom resources.
+ -n <namespace>                   Only enumerate resources in the specified namespace(s).
+ -c                               Only enumerate cluster (non-namespaced) resources.
+ -d <directory>                   Path to output directory (default: /tmp/enum-cattle-resources-<timestamp>).
 ```

--- a/rancher-crd/enumerate-resources/rancher-resource-enumerator.sh
+++ b/rancher-crd/enumerate-resources/rancher-resource-enumerator.sh
@@ -5,48 +5,98 @@ outputdir="/tmp/enum-cattle-resources-$datenow"
 export outputdir
 
 usage() {
-    printf "Rancher Resource Enumerator"
-    printf "Usage: ./rancher-resource-enumerator.sh\n"
+    printf "Rancher Resource Enumerator \n"
+    printf "Usage: ./rancher-resource-enumerator.sh [ -d <directory> -n <namespace> | -c | -a ]\n"
     printf " -h                               Display this help message.\n"
+    printf " -a                               Enumerate all custom resources.\n"
+    printf " -n <namespace>                   Only enumerate resources in the specified namespace(s).\n"
+    printf " -c                               Only enumerate cluster (non-namespaced) resources.\n"
     printf " -d <directory>                   Path to output directory (default: /tmp/enum-cattle-resources-<timestamp>).\n"
     exit 0
 }
 
-while getopts :d:h opt; do
+# Arguments
+optstring="cahd:n:"
+while getopts ${optstring} opt; do
     case ${opt} in
-      h)
-         usage
+      h) usage
         ;;
       d) path=${OPTARG}
-         outputdir="$path-$datenow"
-         export outputdir
-       ;;
-      *)
-          printf "Invalid Option: %s.\n" "$1"
-          usage
-       ;;
-     esac
-done 
+        outputdir="$path-$datenow"
+        export outputdir
+        ;;
+      a) all=1
+        export all
+        ;;
+      n) namespaces=${OPTARG}
+        export namespaces
+        ;;
+      c) cluster=1
+        export cluster
+        ;;
+      *) printf "Invalid Option: %s.\n" "$1"
+        usage
+        ;;
+    esac
+done
 
-# Create output directory
-echo "Output directory set to $outputdir"
-mkdir -p "$outputdir"
+
+# Setup
+setup() {
+  # Create output directory
+  echo "Output directory set to $outputdir"
+  mkdir -p "$outputdir"
+}
 
 # Get cluster resources
-namespaces="$(kubectl get ns --no-headers -o jsonpath='{.items[*].metadata.name}')"
-export namespaces
-kubectl api-resources --verbs=list --namespaced=false -o name | grep cattle.io | xargs -I _ sh -c "echo (cluster) enumerating _ resources...; kubectl get _ -o custom-columns=KIND:.kind,NAME:.metadata.name --no-headers=true --ignore-not-found=true >> $outputdir/_"  
+non_namespaced() {
+  kubectl api-resources --verbs=list --namespaced=false -o name | grep cattle.io | xargs -I _ sh -c "echo '(cluster) enumerating _ resources...'; kubectl get _ -o custom-columns=KIND:.kind,NAME:.metadata.name --no-headers=true --ignore-not-found=true >> $outputdir/_"  
+}
 
 # Get namespaced resources
-for n in $namespaces
-do
-    kubectl api-resources --verbs=list --namespaced=true -o name | grep cattle.io | xargs -I _ sh -c "echo (namespaced) enumerating _ resources in $n...; kubectl get _ -n $n -o custom-columns=KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers=true --ignore-not-found=true >> $outputdir/_"  
-done
+namespaced() {
+  ns="$1"
+  # Select all namespaces if no namespace is specified
+  if [ -z "$ns" ]; then
+    ns="$(kubectl get ns --no-headers -o jsonpath='{.items[*].metadata.name}')"
+  fi
+  # Get all custom resources for validated namespaces
+  for n in $ns
+  do
+      kubectl get ns "$n" -o name && \
+      kubectl api-resources --verbs=list --namespaced=true -o name | grep cattle.io | xargs -I _ sh -c "echo '(namespaced) enumerating _ resources in $n...'; kubectl get _ -n $n -o custom-columns=KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers=true --ignore-not-found=true >> $outputdir/_"
+  done
+}
 
 # Get total counts
-countfiles="$outputdir/*"
-export countfiles
-for f in $countfiles
-do
-    echo 'counting totals...'; wc -l "$f" >> "$outputdir"/totals
-done
+totals() {
+  countfiles="$outputdir/*"
+  echo 'counting totals...'
+  for f in $countfiles
+  do
+      wc -l "$f" >> "$outputdir"/totals
+  done
+  echo "results saved in $outputdir"
+  exit 0
+}
+
+main() {
+  if [ -n "$all" ]; then
+    setup
+    non_namespaced
+    namespaced
+    totals
+  elif [ -n "$cluster" ]; then
+    setup
+    non_namespaced
+    totals
+  elif [ -n "$namespaces" ]; then
+    setup
+    namespaced "$namespaces"
+    totals
+  else
+    usage
+  fi
+}
+
+main

--- a/rancher-crd/enumerate-resources/rancher-resource-enumerator.sh
+++ b/rancher-crd/enumerate-resources/rancher-resource-enumerator.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+datenow="$(date "+%F-%H-%M-%S")"
+outputdir="/tmp/enum-cattle-resources-$datenow"
+export outputdir
+
+usage() {
+    printf "Rancher Resource Enumerator"
+    printf "Usage: ./rancher-resource-enumerator.sh\n"
+    printf " -h                               Display this help message.\n"
+    printf " -d <directory>                   Path to output directory (default: /tmp/enum-cattle-resources-<timestamp>).\n"
+    exit 0
+}
+
+while getopts :d:h opt; do
+    case ${opt} in
+      h)
+         usage
+        ;;
+      d) path=${OPTARG}
+         outputdir="$path-$datenow"
+         export outputdir
+       ;;
+      *)
+          printf "Invalid Option: %s.\n" "$1"
+          usage
+       ;;
+     esac
+done 
+
+# Create output directory
+echo "Output directory set to $outputdir"
+mkdir -p "$outputdir"
+
+# Get cluster resources
+namespaces="$(kubectl get ns --no-headers -o jsonpath='{.items[*].metadata.name}')"
+export namespaces
+kubectl api-resources --verbs=list --namespaced=false -o name | grep cattle.io | xargs -I _ sh -c "echo (cluster) enumerating _ resources...; kubectl get _ -o custom-columns=KIND:.kind,NAME:.metadata.name --no-headers=true --ignore-not-found=true >> $outputdir/_"  
+
+# Get namespaced resources
+for n in $namespaces
+do
+    kubectl api-resources --verbs=list --namespaced=true -o name | grep cattle.io | xargs -I _ sh -c "echo (namespaced) enumerating _ resources in $n...; kubectl get _ -n $n -o custom-columns=KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers=true --ignore-not-found=true >> $outputdir/_"  
+done
+
+# Get total counts
+countfiles="$outputdir/*"
+export countfiles
+for f in $countfiles
+do
+    echo 'counting totals...'; wc -l "$f" >> "$outputdir"/totals
+done


### PR DESCRIPTION
- `rancher-resource-enumerator` discovers all rancher-related CRD's (*.cattle.io) and enumerates the custom resources that currently exist in the cluster.
- Built in options to enumerate all custom resources `-a`, non-namespaced resources `-c`, or custom resources for a space-delimited list of specific namespaces `-n <namespace>` 
