### PR TITLE
Handle RKE2 data-dir when passing runtime flag

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -67,6 +67,10 @@ sherlock() {
     then
       techo "Setting k8s distro as ${DISTRO_FLAG}"
       DISTRO="${DISTRO_FLAG}"
+      if [ "${DISTRO_FLAG}" = "rke2" ]
+        then
+          sherlock-data-dir
+      fi
     else
       echo -n "$(timestamp): Detecting k8s distribution... "
       if $(command -v docker >/dev/null 2>&1)
@@ -91,23 +95,7 @@ sherlock() {
       fi
       if $(command -v rke2 >/dev/null 2>&1)
         then
-          RKE2_BIN=$(dirname $(which rke2))
-          if [ -f /etc/rancher/rke2/config.yaml ]
-            then
-              CUSTOM_DIR=$(awk '$1 ~ /data-dir:/ {print $2}' /etc/rancher/rke2/config.yaml)
-          fi
-          if [[ -z "${CUSTOM_DIR}" && -z "${DATA_DIR}" ]]
-            then
-              RKE2_DIR="/var/lib/rancher/rke2"
-            else
-              if [ -n "${DATA_DIR}" ]
-                then
-                  RKE2_DIR="${DATA_DIR}"
-                else
-                  RKE2_DIR="${CUSTOM_DIR}"
-              fi
-          fi
-          export CRI_CONFIG_FILE="${RKE2_DIR}/agent/etc/crictl.yaml"
+          sherlock-data-dir
           if $(${RKE2_DIR}/bin/crictl ps >/dev/null 2>&1)
             then
               DISTRO=rke2
@@ -115,7 +103,6 @@ sherlock() {
             else
               FOUND+="rke2"
           fi
-          techo "Detecting data-dir... ${RKE2_DIR}"
       fi
       if [ -z $DISTRO ]
         then
@@ -136,6 +123,25 @@ sherlock() {
       INIT="other"
       echo "other"
   fi
+
+}
+
+sherlock-data-dir() {
+
+  echo -n "$(timestamp): Detecting data-dir... "
+  RKE2_BIN=$(dirname $(which rke2))
+  if [ -f /etc/rancher/rke2/config.yaml ]
+    then
+      CUSTOM_DIR=$(awk '$1 ~ /data-dir:/ {print $2}' /etc/rancher/rke2/config.yaml)
+  fi
+  if [[ -z "${CUSTOM_DIR}" ]]
+    then
+      RKE2_DIR="${DATA_DIR}"
+    else
+      RKE2_DIR="${CUSTOM_DIR}"
+  fi
+  echo "${RKE2_DIR}"
+  export CRI_CONFIG_FILE="${RKE2_DIR}/agent/etc/crictl.yaml"
 
 }
 
@@ -750,7 +756,7 @@ fi
 while getopts "c:d:s:r:fph" opt; do
   case $opt in
     c)
-      DATA_DIR="${OPTARG}"
+      FLAG_DATA_DIR="${OPTARG}"
       ;;
     d)
       MKTEMP_BASEDIR="-p ${OPTARG}"
@@ -780,6 +786,7 @@ while getopts "c:d:s:r:fph" opt; do
   esac
 done
 
+DATA_DIR="${FLAG_DATA_DIR:-/var/lib/rancher/rke2}"
 setup
 disk-space
 if [ -n "${DISK_FULL}" ]


### PR DESCRIPTION
Fixes a bug when passing the RKE2 runtime (`-r rke2`), this bypassed declaring the data-dir, causing issues running rke2/crictl/kubectl commands.

- Moved the data-dir handling to a separate function
- Call the function when the runtime flag is provided, and when it's being auto-detected

The PR doesn't change the current logic, but ensures a data-dir is always set.

Current logic:
 - If no data-dir is provided (`-c /path`), set the default
 - If config.yaml has a data-dir set, use that as a preference