### PR TITLE
Reorder distro detection

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -73,16 +73,6 @@ sherlock() {
       fi
     else
       echo -n "$(timestamp): Detecting k8s distribution... "
-      if $(command -v docker >/dev/null 2>&1)
-        then
-          if $(docker ps >/dev/null 2>&1)
-            then
-              DISTRO=rke
-              echo "rke"
-            else
-              FOUND="rke"
-          fi
-      fi
       if $(command -v k3s >/dev/null 2>&1)
         then
           if $(k3s crictl ps >/dev/null 2>&1)
@@ -102,6 +92,16 @@ sherlock() {
               echo "rke2"
             else
               FOUND+="rke2"
+          fi
+      fi
+      if [[ -z "${DISTRO}" && $(command -v docker >/dev/null 2>&1) ]]
+        then
+          if $(docker ps >/dev/null 2>&1)
+            then
+              DISTRO=rke
+              echo "rke"
+            else
+              FOUND="rke"
           fi
       fi
       if [ -z $DISTRO ]


### PR DESCRIPTION
- Shift docker detection (rke) to the end of the conditions
- If `$DISTRO` is already set (k3s/rke2 detected) then don't test for docker (rke)

Resolves: https://github.com/rancherlabs/support-tools/issues/190