### PR TITLE
Copy systemd-resolved conf only if the file exists

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -153,7 +153,10 @@ system-all() {
   hostname -f > $TMPDIR/systeminfo/hostnamefqdn 2>&1
   cp -p /etc/hosts $TMPDIR/systeminfo/etchosts 2>&1
   cp -p /etc/resolv.conf $TMPDIR/systeminfo/etcresolvconf 2>&1
-  cp -p /run/systemd/resolve/resolv.conf $TMPDIR/systeminfo/systemd-resolved 2>&1
+  if [ -e /run/systemd/resolve/resolv.conf ]
+    then
+      cp -p /run/systemd/resolve/resolv.conf $TMPDIR/systeminfo/systemd-resolved 2>&1
+  fi
   date > $TMPDIR/systeminfo/date 2>&1
   free -m > $TMPDIR/systeminfo/freem 2>&1
   uptime > $TMPDIR/systeminfo/uptime 2>&1


### PR DESCRIPTION
This prevents an aesthetic error when running the script if the Linux distro/version does not use systemd-resolved.