### PR TITLE
Revise condition for rke detection

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -73,16 +73,6 @@ sherlock() {
       fi
     else
       echo -n "$(timestamp): Detecting k8s distribution... "
-      if $(command -v docker >/dev/null 2>&1)
-        then
-          if $(docker ps >/dev/null 2>&1)
-            then
-              DISTRO=rke
-              echo "rke"
-            else
-              FOUND="rke"
-          fi
-      fi
       if $(command -v k3s >/dev/null 2>&1)
         then
           if $(k3s crictl ps >/dev/null 2>&1)
@@ -104,7 +94,22 @@ sherlock() {
               FOUND+="rke2"
           fi
       fi
-      if [ -z $DISTRO ]
+      if $(command -v docker >/dev/null 2>&1)
+        then
+          if $(docker ps >/dev/null 2>&1)
+            then
+              if [ -z "${DISTRO}" ]
+                then
+                  DISTRO=rke
+                  echo "rke"
+                else
+                  techo "Found rke, but another distribution ("${DISTRO}") was also found, using "${DISTRO}"..."
+              fi
+            else
+              FOUND="rke"
+          fi
+      fi
+      if [ -z ${DISTRO} ]
         then
           echo -e "\n$(timestamp): couldn't detect k8s distro"
           if [ -n "${FOUND}" ]


### PR DESCRIPTION
Revise the initial PR (https://github.com/rancherlabs/support-tools/pull/196), the condition did not correctly detect RKE.

Tested on RKE

```
root@d-rke-test1:~# bash logs.sh
2022-12-02 00:30:01: Created /tmp/tmp.NX243Wojpj
2022-12-02 00:30:01: Detecting available commands... renice ionoice
2022-12-02 00:30:01: Detecting OS... ubuntu 20.04
2022-12-02 00:30:01: Detecting k8s distribution... rke
2022-12-02 00:30:01: Detecting init type... systemd
2022-12-02 00:30:01: Using discovered data-dir...
2022-12-02 00:30:01: Collecting system info
2022-12-02 00:30:13: Collecting network info
2022-12-02 00:30:14: Collecting docker info
2022-12-02 00:30:18: Collecting rancher logs
2022-12-02 00:30:19: Collecting k8s component logs
2022-12-02 00:30:23: Collecting system pod logs
2022-12-02 00:30:40: Collecting nginx-proxy info
2022-12-02 00:30:40: Collecting k8s directory state
2022-12-02 00:30:40: Collecting k8s certificates
2022-12-02 00:30:41: Collecting rke etcd info
2022-12-02 00:30:41: Collecting etcdctl output
2022-12-02 00:30:43: Collecting system logs from /var/log
2022-12-02 00:30:43: Collecting system logs from journald
2022-12-02 00:30:45: Created /tmp/d-rke-test1-2022-12-02_00_30_43.tar.gz
2022-12-02 00:30:45: Removing /tmp/tmp.NX243Wojpj
```

Tested on RKE2 with docker running

```
root@ip-10-99-11-216:~# bash logs.sh
2022-12-02 00:28:06: Created /tmp/tmp.KXwcVreT4H
2022-12-02 00:28:06: Detecting available commands... renice ionoice
2022-12-02 00:28:06: Detecting OS... ubuntu 20.04
2022-12-02 00:28:06: Detecting k8s distribution... rke2
2022-12-02 00:28:07: Found rke, but another distribution (rke2) was also found, using rke2...
2022-12-02 00:28:07: Detecting init type... systemd
2022-12-02 00:28:07: Using discovered data-dir... /var/lib/rancher/rke2
2022-12-02 00:28:07: Collecting system info
2022-12-02 00:28:18: Collecting network info
2022-12-02 00:28:19: Collecting rke2 info
2022-12-02 00:28:23: Collecting rke2 cluster logs
2022-12-02 00:28:31: Collecting rke2 system pod logs
2022-12-02 00:28:46: Collecting rke2 agent/server logs
2022-12-02 00:28:46: Collecting rke2 directory state
2022-12-02 00:28:46: Collecting rke2 certificates
2022-12-02 00:28:46: Collecting rke2 server certificates
2022-12-02 00:28:46: Collecting rke2 etcd info
2022-12-02 00:28:47: Collecting system logs from /var/log
2022-12-02 00:28:47: Collecting system logs from journald
2022-12-02 00:28:49: Created /tmp/ip-10-99-11-216-2022-12-02_00_28_48.tar.gz
2022-12-02 00:28:49: Removing /tmp/tmp.KXwcVreT4H
```

Relates: https://github.com/rancherlabs/support-tools/issues/190