### PR TITLE
Fix image name for etcd in etcd-tools scripts

### DIFF
--- a/etcd-tools/etcd-join.sh
+++ b/etcd-tools/etcd-join.sh
@@ -231,7 +231,7 @@ ETCDCTL_ENDPOINT="https://0.0.0.0:2379"
 ETCDCTL_CACERT=$(sed 's,^.*ETCDCTL_CACERT=\([^ ]*\).*,\1,g' <<<$RUNLIKE)
 ETCDCTL_CERT=$(sed 's,^.*ETCDCTL_CERT=\([^ ]*\).*,\1,g' <<<$RUNLIKE)
 ETCDCTL_KEY=$(sed 's,^.*ETCDCTL_KEY=\([^ ]*\).*,\1,g' <<<$RUNLIKE)
-ETCD_VERSION=$(sed 's,^.*rancher/coreos-etcd:\([^ ]*\).*,\1,g' <<<$RUNLIKE)
+ETCD_VERSION=$(sed 's,^.*rancher/mirrored-coreos-etcd:\([^ ]*\).*,\1,g' <<<$RUNLIKE)
 INITIAL_ADVERTISE_PEER_URL=$(sed 's,^.*initial-advertise-peer-urls=\([^ ]*\).*,\1,g' <<<$RUNLIKE)
 ETCD_NAME=$(sed 's,^.*name=\([^ ]*\).*,\1,g' <<<$RUNLIKE)
 ETCD_INITIAL_CLUSTER=$(echo $RUNLIKE | sed 's/\s\+/\n/g' | grep -- '--initial-cluster=' | sed 's,--initial-cluster=,,g')

--- a/etcd-tools/restore-etcd-single.sh
+++ b/etcd-tools/restore-etcd-single.sh
@@ -166,7 +166,7 @@ ETCDCTL_ENDPOINT="https://0.0.0.0:2379"
 ETCDCTL_CACERT=$(sed 's,^.*ETCDCTL_CACERT=\([^ ]*\).*,\1,g' <<<${RUNLIKE})
 ETCDCTL_CERT=$(sed 's,^.*ETCDCTL_CERT=\([^ ]*\).*,\1,g' <<<${RUNLIKE})
 ETCDCTL_KEY=$(sed 's,^.*ETCDCTL_KEY=\([^ ]*\).*,\1,g' <<<${RUNLIKE})
-ETCD_VERSION=$(sed 's,^.*rancher/coreos-etcd:\([^ ]*\).*,\1,g' <<<${RUNLIKE})
+ETCD_VERSION=$(sed 's,^.*rancher/mirrored-coreos-etcd:\([^ ]*\).*,\1,g' <<<${RUNLIKE})
 INITIAL_ADVERTISE_PEER_URL=$(sed 's,^.*initial-advertise-peer-urls=\([^ ]*\).*,\1,g' <<<${RUNLIKE})
 ETCD_NAME=$(sed 's,^.*name=\([^ ]*\).*,\1,g' <<<${RUNLIKE})
 INITIAL_CLUSTER=$(echo $RUNLIKE | sed 's/\s\+/\n/g' | grep -- '--initial-cluster=' | sed 's,--initial-cluster=,,g')


### PR DESCRIPTION
The current image name used in restore-etcd-single.sh is incorrect which causes the script to break when trying to refer to the ETCD_VERSION variable. 

Because of the variable not being populated correctly, NEW_RUNLIKE becomes empty at line 222 when running the sed command that refers to the ETCD_VERSION variable.

I also corrected the image name in etcd-join.sh, but I see no usage of the ETCD_VERSION variable within that script.

This fixes issue #191. 