### PR TITLE
Add check for RKE2 and running Rancher pods

### DIFF
--- a/collection/rancher/v2.x/systems-information/systems_summary.sh
+++ b/collection/rancher/v2.x/systems-information/systems_summary.sh
@@ -7,7 +7,7 @@ echo
 
 if [[ ! -z $KUBERNETES_PORT ]];
 then
-  RANCHER_POD=$(kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name | head -n1)
+  RANCHER_POD=$(kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name --field-selector status.phase=Running | head -n1)
   KUBECTL_CMD="kubectl -n cattle-system exec ${RANCHER_POD} -c rancher -- kubectl"
 else
   if $(command -v k3s >/dev/null 2>&1)

--- a/collection/rancher/v2.x/systems-information/systems_summary.sh
+++ b/collection/rancher/v2.x/systems-information/systems_summary.sh
@@ -10,7 +10,10 @@ then
   RANCHER_POD=$(kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=id:metadata.name --field-selector status.phase=Running | head -n1)
   KUBECTL_CMD="kubectl -n cattle-system exec ${RANCHER_POD} -c rancher -- kubectl"
 else
-  if $(command -v k3s >/dev/null 2>&1)
+  if $(command -v rke2 >/dev/null 2>&1)
+  then
+    KUBECTL_CMD="/var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml"
+  elif $(command -v k3s >/dev/null 2>&1)
   then
     KUBECTL_CMD="k3s kubectl"
   else


### PR DESCRIPTION
Recently had a case where the script was pulling a Rancher pod name that was evicted. Adding `--field-selector status.phase=Running` will prevent this.

Same case was initially opened because script was failing on RKE2 nodes. Workaround was to set KUBERNETES_PORT to any value. Added logic to check for RKE2 nodes to prevent issue in the future.