### PR TITLE
Use English at non English environment

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -21,6 +21,9 @@ TIMEOUT=60
 PRIORITY_NICE=19 # lowest
 PRIORITY_IONICE="idle" # lowest
 
+# Set the dmesg date to use English, as non-English environments such as Japanese will display non-English characters in it.
+LANG=C
+
 setup() {
 
   TMPDIR=$(mktemp -d $MKTEMP_BASEDIR) || { techo 'Creating temporary directory failed, please check options'; exit 1; }


### PR DESCRIPTION
At Japanese environment (`LANG=ja_JP.UTF-8`), dmesg log shows trailing Japanese characters.

```
[木  1月 26 08:05:48 2023] BIOS-provided physical RAM map:
```

This patch fixes it to English.

```
[Thu Jan 26 08:05:48 2023] BIOS-provided physical RAM map:
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>