### PR TITLE
Adding script to remove rancher-webhook

### DIFF
--- a/remove-webhook/README.md
+++ b/remove-webhook/README.md
@@ -1,0 +1,24 @@
+## Remove-webhook
+
+Script to remove the rancher-webhook from downstream clusters.
+
+## Background
+
+The rancher webhook was added to downstream clusters beginning with rancher v2.7.2. 
+On a rollback from a version >= 2.7.2 to a version < 2.7.2, the webhook will stay in the downstream clusters. 
+Since each version of the webhook is 1-1 compatible with a specific version of rancher, this can result in unexpected behavior.
+
+## Usage
+
+```bash
+## create a token through the UI. The token should have no scope and be made for a user who is a global admin.
+read -s RANCHER_TOKEN && export RANCHER_TOKEN
+## the server url for rancher - you can get this value thorugh the server-url setting
+read -s RANCHER_URL && export RANCHER_URL
+bash remove-webhook.sh
+```
+For Rancher setups using self-signed certificates, you can specify `--insecure-skip-tls-verify` to force the script to ignore TLS certificate verification. Note that this option is insecure, and should be avoided for production setups.
+
+## Notes
+- The webhook is automatically deployed by rancher in all clusters
+- This script should be run after rolling-back to the desired version (i.e. if going from 2.7.2 -> 2.7.0, only run this script after 2.7.0 is running)

--- a/remove-webhook/remove-webhook.sh
+++ b/remove-webhook/remove-webhook.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+if [ -n "$DEBUG" ]
+then
+    set -x
+fi
+
+usage() {
+    echo "./remove-webhook.sh [--insecure-skip-tls-verify]"
+    echo "Remove the webhook chart in all clusters managed by rancher (excluding the local cluster)"
+    echo "Requires kubectl and helm to be installed and available on \$PATH"
+    echo "--insecure-skip-tls-verify can be set to configure the script to ignore tls verification"
+    echo "RANCHER_TOKEN must be set with an admin token generated with no scope"
+    echo "RANCHER_URL must be set with the url of rancher (no trailing /) - should be the server URL"
+}
+
+if [[ -z "$RANCHER_TOKEN" || -z "$RANCHER_URL" ]]
+then
+	echo "Env vars not properly set"
+	usage
+	exit -1
+fi
+
+tlsVerify="$1"
+
+kubeconfig="
+apiVersion: v1
+kind: Config
+clusters:
+- name: \"local\"
+  cluster:
+    server: \"$RANCHER_URL\"
+
+users:
+- name: \"local\"
+  user:
+    token: \"$RANCHER_TOKEN\"
+
+
+contexts:
+- name: \"local\"
+  context:
+    user: \"local\"
+    cluster: \"local\"
+
+current-context: \"local\"
+"
+
+echo "$kubeconfig" >> .temp_kubeconfig.yaml
+# helm will complain if these are group/world readable
+chmod g-r .temp_kubeconfig.yaml
+chmod o-r .temp_kubeconfig.yaml
+export KUBECONFIG="$(pwd)/.temp_kubeconfig.yaml"
+
+if [[ "$tlsVerify" != "" ]]
+then
+	kubectl config set clusters.local.insecure-skip-tls-verify true 
+fi
+
+clusters=$(kubectl get clusters.management.cattle.io -o jsonpath="{.items[*].metadata.name}")
+for cluster in $clusters
+do
+	if [ "$cluster" == "local" ]
+	then
+		echo "Skipping removing the webhook in the local cluster"
+		continue
+	fi
+	echo "Removing webhook for $cluster"
+	kubectl config set clusters.local.server "$RANCHER_URL/k8s/clusters/$cluster"
+	helm uninstall rancher-webhook -n cattle-system
+done
+
+rm .temp_kubeconfig.yaml


### PR DESCRIPTION
Rancher webhook is now in downstream clusters as of 2.7.2 This can cause issues on rollback to earlier versions, so a script was created to help delete these webhooks