### PR TITLE
improvements to log collector kubeadm collection

### DIFF
--- a/collection/rancher/v2.x/logs-collector/README.md
+++ b/collection/rancher/v2.x/logs-collector/README.md
@@ -55,5 +55,6 @@ Rancher 2.x logs-collector
   -e    End day of journald and docker log collection, # of days relative to the current day (ex: -e 5)
   -r    Override k8s distribution if not automatically detected (rke|k3s|rke2|kubeadm)
   -p    When supplied runs with the default nice/ionice priorities, otherwise use the lowest priorities
+  -k    specify a custom kubeconfig file location (to be used in combination of -r kubeadm)
   -f    Force log collection if the minimum space isn't available
 ```

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -109,16 +109,6 @@ sherlock() {
               FOUND="rke"
           fi
       fi
-      if $(command -v kubeadm >/dev/null 2>&1)
-        then
-          if $(kubeadm version >/dev/null 2>&1)
-            then
-              DISTRO=kubeadm
-              echo "kubeadm"
-            else
-              FOUND+="kubeadm"
-          fi
-      fi
       if [ -z ${DISTRO} ]
         then
           echo -e "\n$(timestamp): couldn't detect k8s distro"

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -594,7 +594,6 @@ kubeadm-k8s() {
   kubectl --kubeconfig=$KUBECONFIG top pod > $TMPDIR/kubeadm/metrics_nodes 2>&1
   kubectl --kubeconfig=$KUBECONFIG top pod --containers=true > $TMPDIR/kubeadm/metrics_containers 2>&1
 
-  techo "Collecting k8s kubeadm static pods list"
   if [ -d $KUBEADM_STATIC_DIR ]; then
      ls -lah $KUBEADM_STATIC_DIR > $TMPDIR/kubeadm/staticpodlist 2>&1
   fi


### PR DESCRIPTION
This PR addresses issue #222

- Removed collection of `cluster-info dump` to avoid gathering of sensible data

- reduced collection of logs in `/var/log/pods/` to only system clusters namespaces

- fixed user variable when ran with sudo

- a custom kubeconfig file location can now be specified with the `-k` switch, however in case of failure the script fallback to `~/.kube/config`. A new function `verify-kubeconfig` has been added


Example:

`sudo ./rancher2_logs_collector.sh -r kubeadm -k /home/tux/kubeconfig`