### PR TITLE
Update kubeconfig how-to

### DIFF
--- a/how-to-retrieve-kubeconfig-from-custom-cluster/README.md
+++ b/how-to-retrieve-kubeconfig-from-custom-cluster/README.md
@@ -1,47 +1,50 @@
-## How to retrieve a kubeconfig from RKE v0.2.x+ or Rancher v2.2.x+
+# How to retrieve a kubeconfig from an RKE1 cluster
 
-During a Rancher outage or other disaster event. You may lose access to a downstream cluster via Rancher and be unable to manage your applications. This process allows to bypass Rancher and connects directly to the downstream cluster.
+During a Rancher outage or other disaster event you may lose access to a downstream cluster via Rancher and be unable to manage your applications. This process creates a kubeconfig to bypass Rancher, it connects directly to the local kube-apiserver on a control plane node.
 
-## Pre-requisites
+**Note**: The [Authorised Cluster Endpoint (ACE)](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#authenticating-directly-with-a-downstream-cluster) is a default option enabled on clusters provisioned by Rancher, this contains a second context which connects directly to the downstream kube-apiserver and also bypasses Rancher.
+
+### Pre-requisites
 
 - Rancher v2.2.x or newer
 - RKE v0.2.x or newer
 - SSH access to one of the controlplane nodes
+- Access to the Docker CLI or root/sudo
 
-## Resolution
+## Retrieve a kubeconfig - using jq
 
-### SSH access
+This option requires `kubectl` and `jq` to be installed on the server.
 
-- You should SSH into one of the controlplane nodes in the cluster
-- You'll need root/sudo or access to the docker cli
+**Note**: kubectl can be copied from the kubelet container
 
-- Copy kubectl from the kubelet container
 ```bash
 docker cp kubelet:/usr/local/bin/kubectl /usr/local/bin/
 ```
 
-### Oneliner (RKE and Rancher custom cluster)
-
-This option requires kubectl and jq to be installed on the server.
-
-```
-kubectl --kubeconfig $(docker inspect kubelet --format '{{ range .Mounts }}{{ if eq .Destination "/etc/kubernetes" }}{{ .Source }}{{ end }}{{ end }}')/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_" > kubeconfig_admin.yaml
-kubectl --kubeconfig kubeconfig_admin.yaml get nodes
-```
-
-### Docker run commands (Rancher custom cluster)
-
-This option does not require kubectl or jq on the server because this uses the `rancher/rancher-agent` image to retrieve the kubeconfig.
-
 - Get kubeconfig
-```
-docker run --rm --net=host -v $(docker inspect kubelet --format '{{ range .Mounts }}{{ if eq .Destination "/etc/kubernetes" }}{{ .Source }}{{ end }}{{ end }}')/ssl:/etc/kubernetes/ssl:ro --entrypoint bash $(docker inspect $(docker images -q --filter=label=org.label-schema.vcs-url=https://github.com/rancher/hyperkube.git) --format='{{index .RepoTags 0}}' | tail -1) -c 'kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_"' > kubeconfig_admin.yaml
+
+```bash
+kubectl --kubeconfig $(docker inspect kubelet --format '{{ range .Mounts }}{{ if eq .Destination "/etc/kubernetes" }}{{ .Source }}{{ end }}{{ end }}')/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_" > kubeconfig_admin.yaml
 ```
 
 - Run `kubectl get nodes`
-```
-docker run --rm --net=host -v $PWD/kubeconfig_admin.yaml:/root/.kube/config:z --entrypoint bash $(docker inspect $(docker images -q --filter=label=org.label-schema.vcs-url=https://github.com/rancher/hyperkube.git) --format='{{index .RepoTags 0}}' | tail -1) -c 'kubectl get nodes'
+```bash
+kubectl --kubeconfig kubeconfig_admin.yaml get nodes
 ```
 
-### Script
+## Retrieve a kubeconfig - without jq
+
+This option does not require `kubectl` or `jq` on the server because this uses the `rancher/rancher-agent` image to retrieve the kubeconfig.
+
+- Get kubeconfig
+```bash
+docker run --rm --net=host -v $(docker inspect kubelet --format '{{ range .Mounts }}{{ if eq .Destination "/etc/kubernetes" }}{{ .Source }}{{ end }}{{ end }}')/ssl:/etc/kubernetes/ssl:ro --entrypoint bash $(docker inspect $(docker images -q --filter=label=org.opencontainers.image.source=https://github.com/rancher/hyperkube.git) --format='{{index .RepoTags 0}}' | tail -1) -c 'kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_"' > kubeconfig_admin.yaml
+```
+
+- Run `kubectl get nodes`
+```bash
+docker run --rm --net=host -v $PWD/kubeconfig_admin.yaml:/root/.kube/config:z --entrypoint bash $(docker inspect $(docker images -q --filter=label=org.opencontainers.image.source=https://github.com/rancher/hyperkube.git) --format='{{index .RepoTags 0}}' | tail -1) -c 'kubectl get nodes''
+```
+
+## Script
 Run `https://raw.githubusercontent.com/rancherlabs/support-tools/master/how-to-retrieve-kubeconfig-from-custom-cluster/rke-node-kubeconfig.sh` and follow the instructions given.

--- a/how-to-retrieve-kubeconfig-from-custom-cluster/rke-node-kubeconfig.sh
+++ b/how-to-retrieve-kubeconfig-from-custom-cluster/rke-node-kubeconfig.sh
@@ -9,7 +9,7 @@ CONTROLPLANE=$(docker ps -q --filter=name=kube-apiserver)
 RANCHER_IMAGE=$(docker inspect $(docker images -q --filter=label=io.cattle.agent=true) --format='{{index .RepoTags 0}}' | tail -1)
 
 if [ -z $RANCHER_IMAGE ]; then
-  RANCHER_IMAGE="${PRIVATE_REGISTRY}rancher/rancher-agent:v2.2.4"
+  RANCHER_IMAGE="${PRIVATE_REGISTRY}rancher/rancher-agent:v2.6.11"
 fi
 
 if [ -d /opt/rke/etc/kubernetes/ssl ]; then
@@ -25,10 +25,16 @@ if [ -s kubeconfig_admin.yaml ]; then
     echo "This is supposed to be run on a node with the 'controlplane' role as it will try to connect to https://127.0.0.1:6443"
     echo "You can manually change the 'server:' parameter inside 'kubeconfig_admin.yaml' to point to a node with the 'controlplane' role"
   fi
-  echo "Kubeconfig is stored at kubeconfig_admin.yaml"
-  echo "You can use on of the following commands to use it:"
-  echo "docker run --rm --net=host -v $PWD/kubeconfig_admin.yaml:/root/.kube/config --entrypoint bash $RANCHER_IMAGE -c 'kubectl get nodes'"
-  echo "kubectl --kubeconfig kubeconfig_admin.yaml get nodes"
+  echo "Kubeconfig is stored at: kubeconfig_admin.yaml
+
+You can use on of the following commands to use it:
+
+  docker run --rm --net=host -v $PWD/kubeconfig_admin.yaml:/root/.kube/config --entrypoint bash $RANCHER_IMAGE -c 'kubectl get nodes'
+
+  kubectl --kubeconfig kubeconfig_admin.yaml get nodes
+
+Note: if kubectl is not available on the node, the binary can be copied from the kubelet container:
+  docker cp kubelet:/usr/local/bin/kubectl /usr/local/bin/"
 else
   echo "Failed to retrieve kubeconfig"
 fi


### PR DESCRIPTION
- Update README to handle new container image label (non-jq example)
- Update wording to cover any RKE1 cluster, add option of using ACE, improve readability