### PR TITLE
Add static pod manifests for RKE2

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -540,6 +540,12 @@ rke2-k8s() {
     done
   fi
 
+  if [ -d ${RKE2_DIR}/agent/pod-manifests ]; then
+    techo "Collecting rke2 static pod manifests"
+    mkdir -p $TMPDIR/rke2/pod-manifests
+    cp -p ${RKE2_DIR}/agent/pod-manifests/* $TMPDIR/rke2/pod-manifests
+  fi
+
   techo "Collecting rke2 agent/server logs"
   for RKE2_LOG_DIR in agent server
     do


### PR DESCRIPTION
Tested on RKE2

```
-rw-r--r-- root/root                      3832 2023-08-31 02:38 ./rke2/pod-manifests/cloud-controller-manager.yaml
-rw-r--r-- root/root                      3080 2023-08-31 02:38 ./rke2/pod-manifests/kube-scheduler.yaml
-rw-r--r-- root/root                      9681 2023-08-31 02:38 ./rke2/pod-manifests/kube-apiserver.yaml
-rw-r--r-- root/root                      6251 2023-08-31 02:38 ./rke2/pod-manifests/kube-controller-manager.yaml
-rw-r--r-- root/root                      3361 2023-08-31 02:36 ./rke2/pod-manifests/etcd.yaml
-rw-r--r-- root/root                      2525 2023-08-31 02:38 ./rke2/pod-manifests/kube-proxy.yaml
```

Resolves: https://github.com/rancherlabs/support-tools/issues/234