### PR TITLE
Add alternative binary install directories for rke2/k3s

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -99,6 +99,8 @@ sherlock() {
             else
               FOUND+="rke2"
           fi
+          echo "$(timestamp): Using RKE2 binaries in... ${RKE2_BIN}"
+          echo "$(timestamp): Using data-dir... ${RKE2_DIR}"
       fi
       if $(command -v docker >/dev/null 2>&1)
         then
@@ -135,13 +137,19 @@ sherlock() {
       echo "other"
   fi
 
-  echo "$(timestamp): Using discovered data-dir... ${RKE2_DIR}"
-
 }
 
 sherlock-data-dir() {
 
-  RKE2_BIN=$(dirname $(which rke2))
+  which rke2 > /dev/null 2>&1
+  if [ $? -eq 0 ]
+    then
+      RKE2_BIN=$(dirname $(which rke2))
+  elif [ -f /opt/rke2/bin/rke2 ]
+    then
+      RKE2_BIN=$(dirname /opt/rke2/bin/rke2)
+  fi
+
   if [ -f /etc/rancher/${DISTRO}/config.yaml ]
     then
       CUSTOM_DIR=$(awk '$1 ~ /data-dir:/ {print $2}' /etc/rancher/${DISTRO}/config.yaml)

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -79,7 +79,7 @@ sherlock() {
       fi
     else
       echo -n "$(timestamp): Detecting k8s distribution... "
-      if $(command -v k3s >/dev/null 2>&1)
+      if $(command -v k3s >/dev/null 2>&1) || $(command -v /opt/bin/k3s >/dev/null 2>&1)
         then
           if $(k3s crictl ps >/dev/null 2>&1)
             then
@@ -89,7 +89,7 @@ sherlock() {
               FOUND+="k3s"
           fi
       fi
-      if $(command -v rke2 >/dev/null 2>&1)
+      if $(command -v rke2 >/dev/null 2>&1) || $(command -v /opt/rke2/bin/rke2 >/dev/null 2>&1)
         then
           sherlock-data-dir
           if $(${RKE2_DIR}/bin/crictl ps >/dev/null 2>&1)


### PR DESCRIPTION
Resolves: https://github.com/rancherlabs/support-tools/issues/253

Currently the k8s distro detection relies on $PATH to include the binaries, in such cases that the alternate directory is used this is often not in the $PATH and fails to detect the distro. To account for this these directories have been added to the logic.

Example from the RKE2 install script:

>   - INSTALL_RKE2_TAR_PREFIX
>     Installation prefix when using the tar installation method.
>     Default is /usr/local, unless /usr/local is read-only or has a dedicated mount point,
>     in which case /opt/rke2 is used instead.
