### PR TITLE
Add default 7 day limit for var log files

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -686,6 +686,11 @@ kubeadm-k8s() {
 
 var-log() {
 
+  if [ -n "${START_DAY}" ]
+    then
+      VAR_LOG_DAYS=${START_DAY}
+  fi
+
   techo "Collecting system logs from /var/log"
   mkdir -p $TMPDIR/systemlogs
 

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -11,6 +11,12 @@ KUBE_CONTAINERS=(etcd etcd-rolling-snapshots kube-apiserver kube-controller-mana
 # Included journald logs
 JOURNALD_LOGS=(docker k3s rke2-agent rke2-server containerd cloud-init systemd-network kubelet kubeproxy rancher-system-agent)
 
+# Included /var/log files
+VAR_LOG_FILES=(syslog messages kern docker cloud-init audit/ dmesg)
+
+# Days of /var/log files to include
+VAR_LOG_DAYS=7
+
 # Minimum space needed to run the script (MB)
 SPACE=1536
 
@@ -682,14 +688,22 @@ var-log() {
 
   techo "Collecting system logs from /var/log"
   mkdir -p $TMPDIR/systemlogs
-  cp -p /var/log/syslog* /var/log/messages* /var/log/kern* /var/log/docker* /var/log/system-docker* /var/log/cloud-init* /var/log/audit/* $TMPDIR/systemlogs 2>/dev/null
+
+  for LOG_FILE in "${VAR_LOG_FILES[@]}"
+    do
+      ls /var/log/${LOG_FILE}* > /dev/null 2>&1
+      if [ $? -eq 0 ]
+        then
+          find /var/log/${LOG_FILE}* -mtime -${VAR_LOG_DAYS} -type f -exec cp -p {} $TMPDIR/systemlogs/ \;
+      fi
+  done
 
   for STAT_PACKAGE in atop sa sysstat
     do
       if [ -d /var/log/${STAT_PACKAGE} ]
         then
           mkdir -p $TMPDIR/systemlogs/${STAT_PACKAGE}-data
-          find /var/log/${STAT_PACKAGE} -mtime -7 -type f -exec cp -p {} $TMPDIR/systemlogs/${STAT_PACKAGE}-data \;
+          find /var/log/${STAT_PACKAGE} -mtime -${VAR_LOG_DAYS} -type f -exec cp -p {} $TMPDIR/systemlogs/${STAT_PACKAGE}-data \;
       fi
   done
 


### PR DESCRIPTION
Limit files collected from /var/log to avoid large log collections when a long history of files is kept

Considered adding a flag for this, however, we already have several similar flags -- open to thoughts?