### PR TITLE
Create serviceaccount.yaml

### DIFF
--- a/cleanup-evicted-pods/serviceaccount.yaml
+++ b/cleanup-evicted-pods/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rke-job-deployer
+  namespace: kube-system


### PR DESCRIPTION
the cron job was getting created but for the rke2 clusters it was looking for an service acocunt to communicate the issue will be fixed when we have an service account for ceonjob 

FailedCreate
Error creating: pods "cleanup-evicted-pods-28516020-" is forbidden: error looking up service account kube-system/rke-job-deployer: serviceaccount "rke-job-deployer" not found