### PR TITLE
Add new option to unset node groups as managed fields for EKS Cluster

### DIFF
--- a/eks-upgrade-using-api/README.md
+++ b/eks-upgrade-using-api/README.md
@@ -41,19 +41,29 @@ export RANCHER_API="<YOUR RANCHER API ENDPOINT>"
 
 > The output will list all the found EKS clusters with their name, id, current version and state.
 
-5. For each EKS cluster you want to upgrade run the following command:
+### Upgrading EKS Clusters
+
+1. For each EKS cluster you want to upgrade run the following command:
 
 ```bash
 # For v2
-./eks-support.sh upgrade -t $RANCHER_TOKEN --endpoint $RANCHER_API --from 1.22 --to 1.23 --name richtest1
+./eks-support.sh upgrade -t $RANCHER_TOKEN --endpoint $RANCHER_API --from 1.22 --to 1.23 --name <EKS_CLUSTER_NAME>
 # For v1
-./eks-support.sh upgrade -t $RANCHER_TOKEN --endpoint $RANCHER_API --from 1.22 --to 1.23 --name richtest1 --aws-secret-key "<AWS SECRET FOR CLUSTER>" --kev1
+./eks-support.sh upgrade -t $RANCHER_TOKEN --endpoint $RANCHER_API --from 1.22 --to 1.23 --name <EKS_CLUSTER_NAME> --aws-secret-key "<AWS SECRET FOR CLUSTER>" --kev1
 ```
 
 > Replace the values of --from, --to and --name with your values.
 
-6. The cluster will start to upgrade. You can check the status of a specific cluster using this command:
+2. The cluster will start to upgrade. You can check the status of a specific cluster using this command:
 
 ```bash
 ./eks-support.sh status -t $RANCHER_TOKEN --endpoint $RANCHER_API --name richtest1
 ```
+
+### Unsetting Node Groups as managed fields for imported EKS Clusters (only for KEv2)
+
+```bash
+# For v2
+./eks-support.sh unset_nodegroups -t $RANCHER_TOKEN --endpoint $RANCHER_API --name <EKS_CLUSTER_NAME>
+```
+

--- a/eks-upgrade-using-kubectl/README.md
+++ b/eks-upgrade-using-kubectl/README.md
@@ -20,7 +20,9 @@ This script requires the following:
 export RANCHER_KUBE="<PATH TO YOUR RANCHER KUBECONFIG>"
 ```
 
-3. Get a list of your EKS clusters using this command
+### Upgrading EKS Clusters
+
+1. Get a list of your EKS clusters using this command
 
 ```bash
 # For v2 
@@ -29,13 +31,20 @@ export RANCHER_KUBE="<PATH TO YOUR RANCHER KUBECONFIG>"
 ./eks-support.sh list -k $RANCHER_KUBE --kev1
 ```
 
-4. For each EKS cluster you want to upgrade run the following command:
+2. For each EKS cluster you want to upgrade run the following command:
 
 ```bash
 # For v2 
-./eks-support.sh upgrade -k $RANCHER_KUBE --from 1.22 --to 1.23 --name richtest1
+./eks-support.sh upgrade -k $RANCHER_KUBE --from 1.22 --to 1.23 --nname <EKS_CLUSTER_NAME>
 # For v1
-./eks-support.sh upgrade -k $RANCHER_KUBE --from 1.22 --to 1.23 --name richtest1 --kev1
+./eks-support.sh upgrade -k $RANCHER_KUBE --from 1.22 --to 1.23 --name <EKS_CLUSTER_NAME> --kev1
 ```
 
 > Replace the values of --from, --to and --name with your values.
+
+### Unsetting Node Groups as managed fields for imported EKS Clusters (only for KEv2)
+
+```bash
+# For v2
+./eks-support.sh unset_nodegroups -k $RANCHER_KUBE --name <EKS_CLUSTER_NAME>
+```


### PR DESCRIPTION
Add new option to unset node groups as managed fields for imported EKS Cluster

Issue: https://github.com/rancher/eks-operator/issues/469