### PR TITLE
Adapted to the new apiVersion 

### DIFF
--- a/NGINX-to-pods-check/check.sh
+++ b/NGINX-to-pods-check/check.sh
@@ -45,9 +45,9 @@ kubectl get namespace -o custom-columns=NAMESPACE:.metadata.name --no-headers | 
 do
 	kubectl get ingress -n "$namespace" -o custom-columns=ingress:.metadata.name --no-headers | while read ingress
 	do
-		kubectl get ingress $ingress -n $namespace -o yaml | grep 'serviceName: ' | awk '{print $2}' | sort | uniq | while read servicename
+		kubectl get ingress $ingress -n $namespace -o yaml | grep 'service:' -A1 | awk '{print $2}' | sort | uniq | awk 'NF {p=1} p' | while read servicename
 		do
-			PORT="$(kubectl get endpoints "$servicename" -n "$namespace" -o yaml | grep 'port:' | awk '{print $2}')"
+			PORT="$(kubectl get endpoints "$servicename" -n "$namespace" -o yaml | grep 'port:' | awk '{print $2}'| head -n 1)"
 			if [[ "$PORT" == 'port:' ]]
 			then
 				PORT="80"

--- a/NGINX-to-pods-check/example-deployment.yml
+++ b/NGINX-to-pods-check/example-deployment.yml
@@ -75,7 +75,7 @@ spec:
     app: webserver-bad
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: webserver-good
@@ -85,12 +85,14 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: webserver-good
-          servicePort: 80
+          service:
+            name: webserver-good
+            port:
+              number: 80
         path: /
-
+        pathType: ImplementationSpecific
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: webserver-bad
@@ -100,6 +102,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: webserver-bad
-          servicePort: 80
+          service:
+            name: webserver-bad
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific


### PR DESCRIPTION
The Ingress apiVersion changed a while ago from extensions/v1beta1 to networking.k8s.io/v1. This introduced the need to make 3 changes:

- Adapted the Ingress in the examples YAML to the new apiVersion. 
- Corrected how to search for the serviceName, as now it is under service: name:
- Restricted the number of ports to curl 1. If there is more than 1 port, the script fails. This could be adapted and introduce another for loop for each port.

These changes are needed for the review of KB: [https://www.suse.com/support/kb/doc/?id=000020011](https://www.suse.com/support/kb/doc/?id=000020011)