### PR TITLE
Fix help param comma separated

### DIFF
--- a/collection/rancher/v2.x/profile-collector/README.md
+++ b/collection/rancher/v2.x/profile-collector/README.md
@@ -37,12 +37,12 @@ The script needs to be downloaded and run with a kubeconfig file pointed to the 
 
 ```
 Rancher 2.x profile-collector
-  Usage: profile-collector.sh [-a rancher -p goroutine heap ]
+  Usage: profile-collector.sh [-a rancher -p goroutine,heap ]
 
   All flags are optional
 
   -a    Application, either rancher or cattle-cluster-agent
-  -p    Profiles to be collected: goroutine, heap, threadcreate, block, mutex, profile
+  -p    Profiles to be collected (comma separated): goroutine,heap,threadcreate,block,mutex,profile
   -s    Sleep time between loops in seconds
   -t    Time of CPU profile collections
   -h    This help

--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -42,7 +42,7 @@ help() {
   All flags are optional
 
   -a    Application, either rancher or cattle-cluster-agent
-  -p    Profiles to be collected: goroutine, heap, threadcreate, block, mutex, profile
+  -p    Profiles to be collected (comma separated): goroutine,heap,threadcreate,block,mutex,profile
   -s    Sleep time between loops in seconds
   -t    Time of CPU profile collections
   -h    This help"

--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -37,7 +37,7 @@ export TZ=UTC
 
 help() {
 	echo "Rancher 2.x profile-collector
-  Usage: profile-collector.sh [-a rancher -p goroutine heap ]
+  Usage: profile-collector.sh [-a rancher -p goroutine,heap ]
 
   All flags are optional
 


### PR DESCRIPTION
Fix help param comma separated instead of spaces 
should read `-p profile,goroutine,heap` instead of  `-p  profile goroutine heap`