### PR TITLE
rfe: added collected data to a single tar ball

### DIFF
--- a/collection/rancher/v2.x/profile-collector/README.md
+++ b/collection/rancher/v2.x/profile-collector/README.md
@@ -33,6 +33,8 @@ The script needs to be downloaded and run with a kubeconfig file pointed to the 
   sudo bash continuous_profiling.sh
   ```
   The script will run until it receives a SIGKILL (Ctrl-C)
+  A tarball will be generated at the same folder where the script is running. Please share that file with Rancher support.
+
 ## Flags
 
 ```

--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -18,6 +18,9 @@ PREFIX="rancher"
 # Profile collection time (only required for CPU profiles)
 DURATION=30
 
+# Support tarball file (profiles will be added here)
+MAIN_FILENAME="profiles-$(date +'%Y-%m-%d_%H_%M').tar"
+
 # Optional Azure storage container SAS URL and token for uploading. Only creation permission is necessary.
 BLOB_URL=
 BLOB_TOKEN=
@@ -122,6 +125,8 @@ collect() {
 		if [ -n "$BLOB_URL" ]; then
 			echo "Uploading ${FILENAME}"
 			curl -H "x-ms-blob-type: BlockBlob" --upload-file /tmp/${FILENAME} "${BLOB_URL}/${FILENAME}?${BLOB_TOKEN}"
+		else
+			tar rf "$MAIN_FILENAME" /tmp/${FILENAME}
 		fi
 
 		echo


### PR DESCRIPTION
Added a new variable and check to create a single tarball with all the profiles and data collected.

To test it:
with a kubeconfig for a local cluster run
`bash continuous_profiling.sh -s 5 -t 1`
 
with a kubeconfig for a DS cluster run:
`bash continuous_profiling.sh -a cattle-cluster-agent -t 1 -s 5`

When a sigkill is received the script will stop. The tarball with the data collected is generated at the same location as the script is running 