### PR TITLE
Add script to patch secrets used by Fleet GitRepos

### DIFF
--- a/fleet-secrets-bro-patch/README.md
+++ b/fleet-secrets-bro-patch/README.md
@@ -1,0 +1,26 @@
+# Fleet | GitRepo Secret Backup Restore Patch
+
+This is a patching script to ensure all secrets used by Fleet `GitRepos` are backed up by the Racnher Backups tool.
+
+The script is designed to fix existing clusters using Fleet and Rancher Backups. When run, it ensures that all secrets used by GitRepos are backed up. Although a bug fix is in progress, it will not be retroactive. Therefore, this script can resolve the current issue.
+
+Additionally, the bug fix will only address `Secrets` created via the Fleet UI of Rancher. It does not cover secrets created outside of the Fleet UI, as those secrets cannot be guaranteed to be "fleet-owned."
+
+By running this patching script on your Rancher cluster, it will identify all secrets used by GitRepos and label them as managed by Fleet. This labeling ensures they are backed up by Rancher Backups.
+
+## Running the script
+To run this script you simply need a valid KUBECONFIG to connect to your Racnher cluster. Then execute the shell script:
+> ./patch_gitrepo_secrets.sh
+
+When run you should see output similar to:
+
+```bash
+./patch_gitrepo_secrets.sh
+Patching unique secret combinations:
+Patching secret: fleet-default:auth-helm-creds
+secret/auth-helm-creds patched
+Patching secret: fleet-local:auth-gitlab-creds
+secret/auth-gitlab-creds patched (no change)
+```
+
+Note: If the secret already has the necessary label it will look like the `secret/auth-gitlab-creds` line above.

--- a/fleet-secrets-bro-patch/README.md
+++ b/fleet-secrets-bro-patch/README.md
@@ -1,15 +1,15 @@
 # Fleet | GitRepo Secret Backup Restore Patch
 
-This is a patching script to ensure all secrets used by Fleet `GitRepos` are backed up by the Racnher Backups tool.
+This is a patching script to ensure all secrets used by Fleet `GitRepos` are backed up by the Rancher Backups tool.
 
-The script is designed to fix existing clusters using Fleet and Rancher Backups. When run, it ensures that all secrets used by GitRepos are backed up. Although a bug fix is in progress, it will not be retroactive. Therefore, this script can resolve the current issue.
+From Rancher v2.8.?? (TBD) and v2.9.0 all `Secrets` created via the Fleet UI in Rancher will be included in Rancher Backups.
 
-Additionally, the bug fix will only address `Secrets` created via the Fleet UI of Rancher. It does not cover secrets created outside of the Fleet UI, as those secrets cannot be guaranteed to be "fleet-owned."
+Any GitRepo `Secrets` created before this, or outside of the Fleet UI in Rancher, will not be included in Rancher Backups.
 
 By running this patching script on your Rancher cluster, it will identify all secrets used by GitRepos and label them as managed by Fleet. This labeling ensures they are backed up by Rancher Backups.
 
 ## Running the script
-To run this script you simply need a valid KUBECONFIG to connect to your Racnher cluster. Then execute the shell script:
+To run this script you simply need a valid KUBECONFIG to connect to your Rancher cluster. Then execute the shell script:
 > ./patch_gitrepo_secrets.sh
 
 When run you should see output similar to:

--- a/fleet-secrets-bro-patch/README.md
+++ b/fleet-secrets-bro-patch/README.md
@@ -15,7 +15,7 @@ To run this script you simply need a valid KUBECONFIG to connect to your Rancher
 When run you should see output similar to:
 
 ```bash
-./patch_gitrepo_secrets.sh
+# ./patch_gitrepo_secrets.sh
 Patching unique secret combinations:
 Patching secret: fleet-default:auth-helm-creds
 secret/auth-helm-creds patched
@@ -24,3 +24,13 @@ secret/auth-gitlab-creds patched (no change)
 ```
 
 Note: If the secret already has the necessary label it will look like the `secret/auth-gitlab-creds` line above.
+
+### Dry-run
+Optionally you can run the script with dry-run flag `-D`, it will produce output like:
+```bash
+# ./patch_gitrepo_secrets.sh -D
+Patching unique secret combinations:
+Would patch secret: fleet-default/auth-6w5gn
+Would patch secret: fleet-default/auth-lfkdr
+Would patch secret: fleet-local/auth-gitlab-creds
+```

--- a/fleet-secrets-bro-patch/patch_gitrepo_secrets.sh
+++ b/fleet-secrets-bro-patch/patch_gitrepo_secrets.sh
@@ -16,7 +16,7 @@ while read -r row; do
 done <<< "$(echo "$output" | awk '{print $0}')"
 
 # Sort and uniq the list of secret combinations
-read -r -a sorted_secret_combinations <<< "$(printf "%s\n" "${secret_combinations[@]}" | sort -u)"
+sorted_secret_combinations=($(printf "%s\n" "${secret_combinations[@]}" | sort -u))
 
 echo "Patching unique secret combinations:"
 for combination in "${sorted_secret_combinations[@]}"; do

--- a/fleet-secrets-bro-patch/patch_gitrepo_secrets.sh
+++ b/fleet-secrets-bro-patch/patch_gitrepo_secrets.sh
@@ -2,7 +2,7 @@
 
 DRYRUN=0
 
-while getopts "D:" opt; do
+while getopts "D" opt; do
   case $opt in
     D) DRYRUN=1;;
     \?) echo "Invalid option: -$OPTARG"; exit 1;;

--- a/fleet-secrets-bro-patch/patch_gitrepo_secrets.sh
+++ b/fleet-secrets-bro-patch/patch_gitrepo_secrets.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+output=$(kubectl get gitrepo -A -o custom-columns=NAMESPACE:.metadata.namespace,CLIENT:.spec.clientSecretName,HELM:.spec.helmSecretName,HELMPATHS:.spec.helmSecretNameForPaths --no-headers)
+
+secret_combinations=()
+while read -r row; do
+  # Extract the namespace and potential secret names from each row
+  namespace=$(echo "$row" | awk '{print $1}')
+  read -r -a secrets <<< "$(echo "$row" | awk '{print $2, $3, $4}')"
+  # Create a list of secret combinations for this namespace
+  for secret in "${secrets[@]}"; do
+    if [ "$secret" != "<none>" ]; then
+      secret_combinations+=("$namespace:$secret")
+    fi
+  done
+done <<< "$(echo "$output" | awk '{print $0}')"
+
+# Sort and uniq the list of secret combinations
+read -r -a sorted_secret_combinations <<< "$(printf "%s\n" "${secret_combinations[@]}" | sort -u)"
+
+echo "Patching unique secret combinations:"
+for combination in "${sorted_secret_combinations[@]}"; do
+  # Set the delimiter
+  IFS=':'
+  # Read the input string into two variables
+  read -r namespace name <<< "$combination"
+  echo "Patching secret: $combination"
+  kubectl patch secret -n "$namespace" "$name" -p '{"metadata": {"labels": {"fleet.cattle.io/managed": "true"}}}'
+done


### PR DESCRIPTION
This PR helps to address this issue: https://github.com/rancher/rancher/issues/45812
Which is a follow up to: https://github.com/rancher/dashboard/issues/11211 
Which will be fixed in 2.9 when this PR merges: https://github.com/rancher/dashboard/pull/11209