### PR TITLE
fix for issue#280

### DIFF
--- a/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
+++ b/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-RANCHER_LEADER="$(kubectl -n kube-system get configmap cattle-controllers -o json | jq -r '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"' | jq -r '.holderIdentity')"
+RANCHER_LEADER="$(kubectl -n kube-system get lease cattle-controllers -o json | jq -r '.spec.holderIdentity')"
 # Display Rancher Pods Information
 kubectl get pod -n cattle-system $RANCHER_LEADER -o custom-columns=NAME:.metadata.name,POD-IP:.status.podIP,HOST-IP:.status.hostIP
 printf "\n$RANCHER_LEADER is the leader in this Rancher instance\n"


### PR DESCRIPTION
Fix for https://github.com/rancherlabs/support-tools/issues/280

The earlier lock was configmapresourcelock, now it's been switched to leaseresourcelock, thus corrected the command.
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go#L178