### PR TITLE
continuous_profiling: also collect leases

### DIFF
--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -112,6 +112,9 @@ collect() {
 			echo
 		done
 
+		echo "Getting leases"
+		kubectl get leases -n kube-system >${TMPDIR}/leases.txt
+
 		echo "Getting pod details"
 		kubectl get pods -A -o wide >${TMPDIR}/get_pods_A_wide.log
 


### PR DESCRIPTION
This helps identifying the Rancher leader pod, among other things.