### PR TITLE
continuous_profiling: uniform file names and extensions

### DIFF
--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -70,8 +70,8 @@ collect() {
 
 		echo "Start: $(date -Iseconds)" >>${TMPDIR}/timestamps.txt
 
-		kubectl top pods -A >>${TMPDIR}/toppods.log
-		kubectl top nodes >>${TMPDIR}/topnodes.log
+		kubectl top pods -A >>${TMPDIR}/top-pods.txt
+		kubectl top nodes >>${TMPDIR}/top-nodes.txt
 
 		CONTAINER=rancher
 		if [ "$APP" == "cattle-cluster-agent" ]; then
@@ -104,16 +104,16 @@ collect() {
 			fi
 
 			echo Getting rancher-event-logs for $pod
-			kubectl get event --namespace cattle-system --field-selector involvedObject.name=${pod} >${TMPDIR}/${pod}-events.log
+			kubectl get event --namespace cattle-system --field-selector involvedObject.name=${pod} >${TMPDIR}/${pod}-events.txt
 			echo
 
 			echo Getting describe for $pod
-			kubectl describe pod $pod -n cattle-system >${TMPDIR}/${pod}-describe.log
+			kubectl describe pod $pod -n cattle-system >${TMPDIR}/${pod}-describe.txt
 			echo
 		done
 
 		echo "Getting pod details"
-		kubectl get pods -A -o wide >${TMPDIR}/get_pods_A_wide.log
+		kubectl get pods -A -o wide >${TMPDIR}/pods-wide.txt
 
 		echo "End:   $(date -Iseconds)" >>${TMPDIR}/timestamps.txt
 


### PR DESCRIPTION
This uses .txt for text files, .log for log files, and uniforms the file names to always use dashes as a separator for clarity.