### PR TITLE
RKE2 data directory improvements

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -852,8 +852,8 @@ rke2-certs() {
       techo "Collecting rke2 directory state"
       mkdir -p $TMPDIR/${DISTRO}/directories
       ls -lah ${RKE2_DATA_DIR}/agent > $TMPDIR/${DISTRO}/directories/rke2agent 2>&1
-      ls -lah ${RKE2_DATA_DIR}/server/manifests > $TMPDIR/${DISTRO}/directories/rke2servermanifests 2>&1
-      ls -lah ${RKE2_DATA_DIR}/server/tls > $TMPDIR/${DISTRO}/directories/rke2servertls 2>&1
+      ls -lahR ${RKE2_DATA_DIR}/server/manifests > $TMPDIR/${DISTRO}/directories/rke2servermanifests 2>&1
+      ls -lahR ${RKE2_DATA_DIR}/server/tls > $TMPDIR/${DISTRO}/directories/rke2servertls 2>&1
       techo "Collecting rke2 certificates"
       mkdir -p $TMPDIR/${DISTRO}/certs/{agent,server}
       AGENT_CERTS=$(find ${RKE2_DATA_DIR}/agent -maxdepth 1 -type f -name "*.crt" | grep -v "\-ca.crt$")


### PR DESCRIPTION
Improvements for RKE2 and logging to help troubleshoot collection issues where the distro is not detected

- Log the output from the collector to a file in the collection as it runs
- Small improvements to detecting rke2 directories
- Renamed detection function to `rke2-setup` as this was only used for rke2
- Renamed the `RKE2_DATA_DIR` var to match it's usage 
- Check the `50-rancher.yaml` file for a custom data-dir as well (future support in v2prov is coming for this)

Initial testing done on an RKE2 standalone cluster