### PR TITLE
<WIP> Add fleet to be profiled

### DIFF
--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -84,11 +84,10 @@ collect() {
       for profile in ${PROFILES[@]}; do
         techo Getting $profile profile for $pod
         if [ "$profile" == "profile" ]; then
-          kubectl exec -n $NAMESPACE $pod -c ${CONTAINER} -- curl -s http://localhost:6060/debug/pprof/${profile}?seconds=${DURATION} -o ${profile}
+          kubectl exec -n $NAMESPACE $pod -c ${CONTAINER} -- curl -s http://localhost:6060/debug/pprof/${profile}?seconds=${DURATION} >${TMPDIR}/${pod}-${profile}-$(date +'%Y-%m-%dT%H_%M_%S')
         else
-          kubectl exec -n $NAMESPACE $pod -c ${CONTAINER} -- curl -s http://localhost:6060/debug/pprof/${profile} -o ${profile}
+          kubectl exec -n $NAMESPACE $pod -c ${CONTAINER} -- curl -s http://localhost:6060/debug/pprof/${profile} >${TMPDIR}/${pod}-${profile}-$(date +'%Y-%m-%dT%H_%M_%S')
         fi
-        kubectl cp -n $NAMESPACE -c ${CONTAINER} ${pod}:${profile} ${TMPDIR}/${pod}-${profile}-$(date +'%Y-%m-%dT%H_%M_%S')
       done
 
       techo Getting logs for $pod

--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Which app to profile? Supported choices: rancher, cattle-cluster-agent
+# Which app to profile? Supported choices: rancher, cattle-cluster-agent, fleet-controller, fleet-agent
 APP=rancher
 
 # Namespace  of the app, optional
@@ -46,7 +46,7 @@ help() {
 
   All flags are optional
 
-  -a    Application, either rancher or cattle-cluster-agent
+  -a    Application: rancher, cattle-cluster-agent, fleet-controller, or fleet-agent
   -p    Profiles to be collected (comma separated): goroutine,heap,threadcreate,block,mutex,profile
   -s    Sleep time between loops in seconds
   -t    Time of CPU profile collections
@@ -148,7 +148,7 @@ while getopts "a:p:d:s:t:h" opt; do
   case $opt in
   a)
     APP="${OPTARG}"
-    if [ "${APP}" != "rancher" ] && [ "${APP}" != "cattle-cluster-agent" ]; then
+    if [ "${APP}" != "rancher" ] && [ "${APP}" != "cattle-cluster-agent" ] && [ "${APP}" != "fleet-controller" ] && [ "${APP}" != "fleet-agent" ]; then
       help
     fi
     ;;
@@ -205,7 +205,15 @@ rancher)
   loglevel debug
   ;;
 "cattle-cluster-agent")
-  CONTAINER=cluster-agent
+  CONTAINER=cluster-register
+  ;;
+"fleet-controller")
+  CONTAINER=$APP
+  NAMESPACE=cattle-fleet-system
+  ;;
+"fleet-agent")
+  CONTAINER=$APP
+  NAMESPACE=cattle-fleet-local-system
   ;;
 esac
 

--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -54,6 +54,16 @@ help() {
 
 }
 
+timestamp() {
+  date "+%Y-%m-%d %H:%M:%S"
+
+}
+
+techo() {
+  echo "$(timestamp): $*"
+
+}
+
 collect() {
 
   while true; do
@@ -69,11 +79,6 @@ collect() {
 
     kubectl top pods -A >>${TMPDIR}/top-pods.txt
     kubectl top nodes >>${TMPDIR}/top-nodes.txt
-
-    CONTAINER=rancher
-    if [ "$APP" == "cattle-cluster-agent" ]; then
-      CONTAINER=cluster-register
-    fi
 
     for pod in $(kubectl -n $NAMESPACE get pods -l app=${APP} --no-headers -o custom-columns=name:.metadata.name); do
       for profile in ${PROFILES[@]}; do
@@ -193,19 +198,15 @@ loglevel() {
 
 }
 
-timestamp() {
-  date "+%Y-%m-%d %H:%M:%S"
-
-}
-
-techo() {
-  echo "$(timestamp): $*"
-
-}
-
-# APP=rancher only: set logging to debug
-if [ "$APP" == "rancher" ]; then
+# set the container for the app being profiled
+case $APP in
+rancher)
+  CONTAINER=rancher
   loglevel debug
-fi
+  ;;
+"cattle-cluster-agent")
+  CONTAINER=cluster-agent
+  ;;
+esac
 
 collect


### PR DESCRIPTION
in order to add fleet a few changes had to be made to the collection script.
I created a function to change rancher log level, added a case so we can set up anything necessary before calling collect (and that does not need to be in the main loop)
main break change should be the way we collect the profiles now, I had to move away from kubectl cp, as fleet has a read-only namespace from 0.10+. So instead we are doing a simple output (>) 

TO;DO
check if fleet-agent is upstream cluster (cattle-fleet-local-system) or downstream (cattle-fleet-system)
collect gitjobs logs 
collect fleet data outside the main loop:
```
for r in gitjobs gitrepos bundles bundledeployments; do
  kubectl get $r -A -o yaml | gzip -c > $r-list-$TS.gz
done
```