### PR TITLE
Fix failure on collector-output.log file not found

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -1338,4 +1338,4 @@ if [ $OBFUSCATE ]
 fi
 archive
 cleanup
-techo "Finished"
+echo "$(timestamp): Finished"


### PR DESCRIPTION
```sh
$ sudo ./rancherlogcollector.sh -d logs
2024-08-19 09:46:21: Created logs/tmp.Ix35lA1TJv
2024-08-19 09:46:21: Detecting available commands... renice ionoice
2024-08-19 09:46:21: Detecting OS... ubuntu 22.04
2024-08-19 09:46:21: Detecting k8s distribution... k3s
2024-08-19 09:46:21: Detecting init type... systemd
2024-08-19 09:46:21: Collecting system info
2024-08-19 09:46:28: Collecting network info
2024-08-19 09:46:28: Collecting provisioning info
2024-08-19 09:46:34: Collecting k3s info
2024-08-19 09:46:41: Collecting k3s cluster logs
2024-08-19 09:46:47: Collecting system pod logs
2024-08-19 09:46:56: Collecting k3s directory state
2024-08-19 09:46:56: Collecting k3s certificates
2024-08-19 09:46:56: Collecting k3s server certificates
2024-08-19 09:46:56: Collecting k3s etcd info
2024-08-19 09:46:56: Collecting k3s etcd metrics
2024-08-19 09:46:56: Collecting system logs from /var/log
2024-08-19 09:46:56: Collecting system logs from journald
2024-08-19 09:46:56: Created logs/ip-12-34-56-78-2024-08-19_09_46_21.tar.gz
2024-08-19 09:46:57: Removing logs/tmp.Ix35lA1TJv
tee: logs/tmp.Ix35lA1TJv/ip-12-34-56-78-2024-08-19_09_46_21/collector-output.log: No such file or directory
2024-08-19 09:46:57: Finished
```

This PR fixes the above error from `tee` when 'Finished' is printed; the error occurs because the TMPDIR is already deleted and there is not collector-output.log file to write to.
Use normal echo instead of techo, 'Finished' will not be printed to `collector-output.log`.