### PR TITLE
Fixed RKE kubeconfig retrieval script for newer Rancher and RKE versions

### DIFF
--- a/how-to-retrieve-kubeconfig-from-custom-cluster/rke-node-kubeconfig.sh
+++ b/how-to-retrieve-kubeconfig-from-custom-cluster/rke-node-kubeconfig.sh
@@ -18,7 +18,18 @@ else
   K8S_SSLDIR=/etc/kubernetes/ssl
 fi
 
-docker run --rm --net=host -v $K8S_SSLDIR:/etc/kubernetes/ssl:ro --entrypoint bash $RANCHER_IMAGE -c 'kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_"' > kubeconfig_admin.yaml
+# Determine object type for full-cluster-state (depends on Rancher/RKE version), can be either a configmap (older versions) or a secret (newer versions)
+FULL_CLUSTER_STATE_TYPE=$(docker run --rm --net=host -v $K8S_SSLDIR:/etc/kubernetes/ssl:ro --entrypoint bash $RANCHER_IMAGE -c 'kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o jsonpath='{.kind}' 2>/dev/null || kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get secret -n kube-system full-cluster-state -o jsonpath='{.kind}' 2>/dev/null')
+
+# Generate kubeconfig depending on object type for full-cluster-state
+if [ "$FULL_CLUSTER_STATE_TYPE" = "Secret" ]; then
+  docker run --rm --net=host -v $K8S_SSLDIR:/etc/kubernetes/ssl:ro --entrypoint bash $RANCHER_IMAGE -c 'kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get secret -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | base64 -d | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_"' > kubeconfig_admin.yaml
+elif [ "$FULL_CLUSTER_STATE_TYPE" = "ConfigMap" ]; then
+  docker run --rm --net=host -v $K8S_SSLDIR:/etc/kubernetes/ssl:ro --entrypoint bash $RANCHER_IMAGE -c 'kubectl --kubeconfig /etc/kubernetes/ssl/kubecfg-kube-node.yaml get configmap -n kube-system full-cluster-state -o json | jq -r .data.\"full-cluster-state\" | jq -r .currentState.certificatesBundle.\"kube-admin\".config | sed -e "/^[[:space:]]*server:/ s_:.*_: \"https://127.0.0.1:6443\"_"' > kubeconfig_admin.yaml
+else
+  echo "Invalid type for object \"full-cluster-state\" (should be a Secret or a ConfigMap). Exiting..."
+  exit 1
+fi
 
 if [ -s kubeconfig_admin.yaml ]; then
   if [ -z $CONTROLPLANE ]; then


### PR DESCRIPTION
Newer versions of Rancher/RKE have migrated the full-cluster-state ConfigMap to a Secret due to the following security advisory: [https://github.com/rancher/rke/security/advisories/GHSA-6gr4-52w6-vmqx](https://github.com/rancher/rke/security/advisories/GHSA-6gr4-52w6-vmqx)

This PR updates the script to retrieve the kubeconfig on RKE clusters when relying on the full-cluster-state object and works now on both the older (ConfigMap) and newer versions (Secret).

The corresponding README was also updated for the manual steps.