### PR TITLE
Add workaround for agent strict verify on existing Windows nodes

### DIFF
--- a/windows-agent-strict-verify/README.md
+++ b/windows-agent-strict-verify/README.md
@@ -1,0 +1,80 @@
+# Enabling agent strict TLS verification on existing Windows nodes
+
+In certain conditions, Windows nodes will not respect the Agent TLS Mode value set on the Rancher server. This setting was implemented in Rancher 2.9.0 and 2.8.6
+
+Windows nodes will not respect this setting if the following two conditions are true
+
+1. The node was provisioned using a Rancher version older than 2.9.2 or 2.8.8, and continues to be used after a Rancher upgrade to 2.9.2, 2.8.8, or greater
+2. The node is running a version of rke2 _older_ than the August 2024 patches. (i.e. any version _lower_ than v1.30.4, v1.29.8, v1.28.13, v1.27.16.)
+
+## Workaround
+
+In order to retroactively enable strict TLS verification on Windows nodes, the following process must be followed. A Powershell script, `update-node.ps1` has been included to automate some parts of this process, however some steps (such as retrieving the required credentials used by the script) must be done manually. 
+
+
+This process needs to be repeated for each Windows node joined to the cluster, but does not need to be done for newly provisioned nodes after Rancher has been upgraded to at least 2.9.2 or 2.8.8 - even if the rke2 version is older than the August patches. In scenarios where it is possible / safe to reprovision the impacted Windows nodes, this process may not be needed. 
+
+1. Stop the `rancher-wins` service using the `Stop-Service` PowerShell Command (`Stop-Service rancher-wins`)
+
+2. Update the version of `wins.exe` running on the node. This can either be done manually, or via the `update-node.ps1` PowerShell script by passing the `-DownloadWins` flag
+    1. If a manual approach is taken, download the latest [version of rancher-wins from GitHub](https://github.com/rancher/wins/releases) (at least version `0.4.18`) and place the updated binary in the `c:/usr/local/bin` and `c:/Windows` directories, replacing the existing binaries.
+
+    2. If the automatic approach is taken, then you must include the `-DownloadWins` flag when invoking `update-node.ps1`. The version of `rancher-wins` packaged within your Rancher server will then be downloaded.
+        + You must ensure that you are running a version of Rancher which embeds at _least_ `rancher-wins` `v0.4.18`. This version is included in Rancher v2.9.2, v2.8.8, and above.
+        + Refer to the [`Obtaining the CATTLE_TOKEN and CATTLE_SERVER variables`](#obtaining-the-cattle_token-and-cattle_server-variables) section below to retrieve the required `CATTLE_TOKEN` and `CATTLE_SERVER` variables.
+
+3. Manually update the `rancher-wins` config file to enable strict tls verification
+    1. This file is located in `c:/etc/rancher/wins/config`.
+        1. At the root level (i.e. a new line just before the `system-agent` field) add the following value `agentStrictTLSMode: true`
+        2. An [example configuration file](#example-updated-wins-config-file) can be seen at the bottom of this file 
+
+4. If needed, regenerate the rancher connection file
+    1. To determine if you need to do this, look at the `/var/lib/rancher/agent/rancher2_connection_info.json` file. If you intend to use strict validation, this file must contain a valid `ca-certificate-data` field.
+    2. If this field is missing
+        1. Refer to the [`Obtaining the CATTLE_TOKEN and CATTLE_SERVER variables`](#obtaining-the-cattle_token-and-cattle_server-variables) section to retrieve the required `CATTLE_TOKEN` and `CATTLE_SERVER` parameters
+        2. Create a new file containing the `update-node.ps1` script and run it, ensuring you properly pass the `CATTLE_SERVER` value to the `-RancherServerURL` flag, and the `CATTLE_TOKEN` value to the `-Token` flag.
+           1. Depending on whether you wish to manually update `rancher-wins`, run one of the following two commands
+              1. `./update-node.ps1 -RancherServerURL $CATTLE_SERVER -Token $CATTLE_TOKEN`
+              2. `./update-node.ps1 -RancherServerURL $CATTLE_SERVER -Token $CATTLE_TOKEN -DownloadWins`
+           2. Confirm that the `rancher2_connection_info.json` file contains the correct CA data.
+
+5. Confirm the proper version of `rancher-wins` has been installed by running `win.exe --version`
+6. Restart the node (`Restart-Computer`). 
+   1. If the node is running an RKE2 version older than the August patches, you **must** restart the node otherwise pod networking will be impacted. 
+
+### Obtaining the `CATTLE_TOKEN` and `CATTLE_SERVER` variables
+
+- You must be a cluster administrator or have an account permitted to view cluster secrets in order to use this script, as the `CATTLE_TOKEN` is stored in a Kubernetes secret. You cannot simply generate an API token using the Rancher UI. 
+- To obtain the `CATTLE_TOKEN` and `CATTLE_SERVER` values using the Rancher UI
+  1. Open Rancher's Cluster Explorer UI for the cluster which contains the relevant Windows nodes. 
+  2. In the left hand section, under `More Resources`, go to `Core`, and then finally, `Secrets`. 
+  3. Find the secret named `stv-aggregation`, and copy the `CATTLE_SERVER` and `CATTLE_TOKEN` fields. 
+  4. Pass `CATTLE_TOKEN` to the `-Token` flag, and `CATTLE_SERVER` to the `-RancherServerURL` flag.
+- To obtain the `CATTLE_TOKEN` and `CATTLE_SERVER` values using kubectl 
+  1. `kubectl get secret -n cattle-system stv-aggregation --template={{.data.CATTLE_TOKEN}} | base64 -d`
+  2. `kubectl get secret -n cattle-system stv-aggregation --template={{.data.CATTLE_SERVER}} | base64 -d`
+
+### Example updated wins config file
+
+```yaml
+# This file is located at c:/etc/rancher/wins/config
+white_list:
+  processPaths:
+    - C:/etc/rancher/wins/powershell.exe
+    - C:/etc/rancher/wins/wins-upgrade.exe
+    - C:/etc/wmi-exporter/wmi-exporter.exe
+    - C:/etc/windows-exporter/windows-exporter.exe
+  proxyPorts:
+    - 9796
+agentStrictTLSMode: true
+systemagent:
+  workDirectory: C:/var/lib/rancher/agent/work
+  appliedPlanDirectory: C:/var/lib/rancher/agent/applied
+  remoteEnabled: true
+  preserveWorkDirectory: false
+  connectionInfoFile: C:/var/lib/rancher/agent/rancher2_connection_info.json
+csi-proxy:
+  url: https://haffel-rancher.cp-dev.rancher.space/assets/csi-proxy-%[1]s.tar.gz
+  version: v1.1.3
+  kubeletPath: C:/bin/kubelet.exe
+```

--- a/windows-agent-strict-verify/update-node.ps1
+++ b/windows-agent-strict-verify/update-node.ps1
@@ -1,0 +1,80 @@
+<#
+    .SYNOPSIS
+    Updates the rancher_connection_info.json file on Windows nodes and optionally downloads the latest version of rancher-wins from the specified Rancher server
+
+    .PARAMETER RancherServerURL
+    The HTTPs URL of the Rancher server which manages the cluster this node is joined to
+
+    .PARAMETER Token
+    The Rancher API token tracked in the stv-aggregation secret
+
+    .PARAMETER ForceRegeneration
+    When set to true, this script will overwrite the rancher2_connection_info.json file, even if the cetificate-authority-data field is present
+
+    .PARAMETER DownloadWins
+    When set to true, this script will reach out to the RancherServerURL API and download the version of rancher-wins embedded in that sever
+#>
+
+param (
+    [Parameter()]
+    [String]
+    $RancherServerURL,
+
+    [Parameter()]
+    [String]
+    $Token,
+
+    [Parameter()]
+    [Switch]
+    $ForceRegeneration,
+
+    [Parameter()]
+    [Switch]
+    $DownloadWins
+)
+
+if ($DownloadWins -eq $true) {
+    # Download the latest verson of wins from the rancher server
+    $responseCode = $(curl.exe --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" --ssl-no-revoke -sfL "$RancherServerURL/assets/wins.exe" -o "/usr/local/bin/wins.exe")
+    switch ( $responseCode ) {
+        { "ok200", 200 } {
+            Write-LogInfo "Successfully downloaded the wins binary."
+            break
+        }
+        default {
+            Write-LogError "$responseCode received while downloading the wins binary. Double check that the correct RancherServerURL has been provided"
+            exit 1
+        }
+    }
+    Copy-Item -Path "/usr/local/bin/wins.exe" -Destination "c:\Windows\wins.exe" -Force
+}
+
+# Check the current connection file to determine if CA data is already present.
+$info = (Get-Content C:\var\lib\rancher\agent\rancher2_connection_info.json -ErrorAction Ignore)
+if (($null -ne $info) -and (($info | ConvertFrom-Json).kubeConfig).Contains("certificate-authority-data")) {
+    if (-Not $ForceRegeneration) {
+        Write-Host "certificate-authority-data is already present in rancher2_connection_info.json"
+        exit 0
+    }
+}
+
+$CATTLE_ID=(Get-Content /etc/rancher/wins/cattle-id -ErrorAction Ignore)
+if (($null -eq $CATTLE_ID) -or ($CATTLE_ID -eq "")) {
+    Write-Host "Could not obtain required CATTLE_ID value from node"
+    exit 1
+}
+
+Write-Host "Updating rancher2_connection_info.json file"
+
+$responseCode = $(curl.exe --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n " --ssl-no-revoke -sfL "$RancherServerURL/v3/connect/agent" -o /var/lib/rancher/agent/rancher2_connection_info.json -H "Authorization: Bearer $Token" -H "X-Cattle-Id: $CATTLE_ID" -H "Content-Type: application/json")
+
+switch ( $responseCode ) {
+    { $_ -in "ok200", 200 } {
+        Write-Host "Successfully downloaded Rancher connection information."
+        exit 0
+    }
+    default {
+        Write-Host "$responseCode received while downloading Rancher connection information. Double check that the correct RancherServerURL and Token have been provided"
+        exit 1
+    }
+}


### PR DESCRIPTION
In certain circumstances, Windows nodes will not respect the agent TLS mode configured for the Rancher server. This will occur if the following two conditions are true 

+ The Windows node was provisioned on a version of Rancher older than 2.9.2 or 2.8.8
+ The Windows node is running a deprecated version of rke2 (i.e. any version _lower_ than v1.30.4, v1.29.8, v1.28.13, v1.27.16.)

Nodes which do not meet the above circumstances will be automatically upgraded by Rancher after Rancher has been upgraded.

This PR presents a process and PowerShell script that can be used to manually update existing Windows nodes which will not be automatically updated by Rancher. To follow this process, the user must have access to the `stv-aggregation` secret in the downstream cluster. This process must be repeated for each node joined to the cluster. This process may not be needed in circumstances where the node can be easily / safely deleted and reprovisioned. 