### PR TITLE
Remove reference to data collection from non-Rancher managed clusters

### DIFF
--- a/collection/rancher/v2.x/supportability-review/README.md
+++ b/collection/rancher/v2.x/supportability-review/README.md
@@ -252,7 +252,7 @@ ERRO[0000] could not retrieve list of pods: pods is forbidden: User "u-mrhdf" ca
 The user (Bearer Token) has access but not full permission. ## Cluster member vs Owner
 
 ## Additional use
-The script could be run in RKE1/RKE2/K3S clusters not managed by Rancher
+
 ### Note
 
 1. **Download the `collect.sh` script on a Linux node and make it executable**


### PR DESCRIPTION
This removes a reference to SR data collection from clusters that are not managed by Rancher, as the SR only supports SUSE Rancher Prime environments, so this could cause confusion