### PR TITLE
Updating supportability-review collection scripts (v0.76.0)

### DIFF
--- a/collection/rancher/v2.x/supportability-review/cluster-collector.sh
+++ b/collection/rancher/v2.x/supportability-review/cluster-collector.sh
@@ -109,6 +109,7 @@ collect_common_cluster_info() {
   kubectl get deploy -n cattle-system -o json | jq '.items[] | select(.metadata.name=="cattle-cluster-agent") | .status.conditions[] | select(.type=="Available") | .status == "True"' > cattle-cluster-agent-is-running
   kubectl get deploy -n cattle-fleet-system -o json > cattle-fleet-system-deploy.json
   kubectl get deploy -n cattle-neuvector-system -o json > cattle-neuvector-system-deploy.json
+  kubectl get statefulsets -n cattle-fleet-system -o json > cattle-fleet-system-statefulsets.json
   kubectl get settings.management.cattle.io server-version -o json > server-version.json
   kubectl get clusters.management.cattle.io -o json > clusters.management.cattle.io.json
   kubectl get storageclasses.storage.k8s.io -A -o json > storageclasses.storage.k8s.io.json


### PR DESCRIPTION
Fixed to collect `StatefulSet` because Rancher v2.9 runs `fleet-agent` with `StatefulSet` https://github.com/rancher/supportability-review/pull/1449.