### PR TITLE
Revert to /var/log/pods if kube-api is unavailable

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -640,18 +640,18 @@ rke2-k8s() {
   techo "Collecting rke2 system pod logs"
   if [[ ${RKE2_SERVER} && ! ${API_SERVER_OFFLINE} ]]; then
     KUBECONFIG=/etc/rancher/${DISTRO}/rke2.yaml
-        for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
-          for SYSTEM_POD in $(${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
-            ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE logs --all-containers $SYSTEM_POD > $TMPDIR/${DISTRO}/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD 2>&1
-            ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE logs -p --all-containers $SYSTEM_POD > $TMPDIR/${DISTRO}/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD-previous 2>&1
-          done
-        done
-    elif [[ ${RKE2_AGENT} || ${API_SERVER_OFFLINE} ]]; then
-      for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
-        if ls -d /var/log/pods/$SYSTEM_NAMESPACE* > /dev/null 2>&1; then
-          cp -r -p /var/log/pods/$SYSTEM_NAMESPACE* $TMPDIR/${DISTRO}/podlogs/
-        fi
+    for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
+      for SYSTEM_POD in $(${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE get pods --no-headers -o custom-columns=NAME:.metadata.name); do
+        ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE logs --all-containers $SYSTEM_POD > $TMPDIR/${DISTRO}/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD 2>&1
+        ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG -n $SYSTEM_NAMESPACE logs -p --all-containers $SYSTEM_POD > $TMPDIR/${DISTRO}/podlogs/$SYSTEM_NAMESPACE-$SYSTEM_POD-previous 2>&1
       done
+    done
+  elif [[ ${RKE2_AGENT} || ${API_SERVER_OFFLINE} ]]; then
+    for SYSTEM_NAMESPACE in "${SYSTEM_NAMESPACES[@]}"; do
+      if ls -d /var/log/pods/$SYSTEM_NAMESPACE* > /dev/null 2>&1; then
+        cp -r -p /var/log/pods/$SYSTEM_NAMESPACE* $TMPDIR/${DISTRO}/podlogs/
+      fi
+    done
   fi
 
   if [ -d ${RKE2_DATA_DIR}/agent/pod-manifests ]; then

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -543,10 +543,17 @@ k3s-k8s() {
 
   if [ -d /var/lib/rancher/${DISTRO}/agent ]; then
     K3S_AGENT=true
+    KUBECONFIG=/var/lib/rancher/${DISTRO}/agent/kubelet.kubeconfig
+    k3s kubectl --kubeconfig=$KUBECONFIG get --raw='/healthz' --request-timeout=5s > /dev/null 2>&1
+    if [ $? -ne 0 ]
+      then
+        API_SERVER_OFFLINE=true
+        techo "kube-apiserver is offline, collecting local pod logs only"
+    fi
   fi
   if [ -d /var/lib/rancher/${DISTRO}/server ]; then
     K3S_SERVER=true
-    k3s kubectl get --raw='/healthz' > /dev/null 2>&1
+    k3s kubectl get --raw='/healthz' --request-timeout=5s > /dev/null 2>&1
     if [ $? -ne 0 ]
       then
         API_SERVER_OFFLINE=true
@@ -602,10 +609,18 @@ rke2-k8s() {
 
   if [ -f ${RKE2_DATA_DIR}/agent/kubelet.kubeconfig ]; then
     RKE2_AGENT=true
+    KUBECONFIG=${RKE2_DATA_DIR}/agent/kubelet.kubeconfig
+    ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG get --raw='/healthz' --request-timeout=5s > /dev/null 2>&1
+    if [ $? -ne 0 ]
+      then
+        API_SERVER_OFFLINE=true
+        techo "kube-apiserver is offline, collecting local pod logs only"
+    fi
   fi
   if [ -f /etc/rancher/${DISTRO}/rke2.yaml ]; then
     RKE2_SERVER=true
-    ${RKE2_DATA_DIR}/bin/kubectl get --raw='/healthz' > /dev/null 2>&1
+    KUBECONFIG=/etc/rancher/${DISTRO}/rke2.yaml
+    ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG get --raw='/healthz' --request-timeout=5s > /dev/null 2>&1
     if [ $? -ne 0 ]
       then
         API_SERVER_OFFLINE=true


### PR DESCRIPTION
Resolves https://github.com/rancherlabs/support-tools/issues/312

Tested on RKE2 and k3s, simulated the kube-apiserver being unavailable with `iptables -I INPUT -p tcp --dport 6443 -j REJECT`