### PR TITLE
Adding DNS tests to overlay test as an optional check

### DIFF
--- a/swiss-army-knife/README.md
+++ b/swiss-army-knife/README.md
@@ -16,20 +16,25 @@ TLDR; This image has a lot of useful tools that can be used for scripting and tr
 ## Example deployments
 
 ### Overlay Test
-As part of Rancher's overlay test, which can be found [here](https://rancher.com/docs/rancher/v2.6/en/troubleshooting/networking/). You can be deployed to the Rancher environment by running the following command:
-```
+As part of Rancher's overlay test, which can be found [here](https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking#check-if-overlay-network-is-functioning-correctly). This can be deployed to the cluster by running the following command:
+```bash
 kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/overlaytest.yaml
 ```
 
 This will deploy a deamonset that will run on all nodes in the cluster. These pods will be running `tail -f /dev/null,` which will do nothing but keep the pod running.
 
 You can run the overlay test script by running the following command:
-```
+```bash
 curl -sfL https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/overlaytest.sh | bash
 ```
 
 ### Admin Tools
 This deployment will deploy `swiss-army-knife` to all nodes in the cluster but with additional permissions and privileges. This is useful for troubleshooting and managing your Rancher environment. The pod will be running `tail -f /dev/null,` which will do nothing but keep the pod running.
+
+This can be deployed to the cluster by running the following command:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/admin-tools.yaml
+```
 
 Inside the pod, you will be able to un `kubectl` commands with cluster-admin privileges. Along with this pod being able to gain full access to the node, including the ability to gain a root shell on the node. By running the following commands:
 - `kubectl -n kube-system get pods -l app=swiss-army-knife -o wide`

--- a/swiss-army-knife/admin-tools.yaml
+++ b/swiss-army-knife/admin-tools.yaml
@@ -57,11 +57,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: swiss-army-knife
+      app: swiss-army-knife
   template:
     metadata:
       labels:
-        name: swiss-army-knife
+        app: swiss-army-knife
     spec:
       tolerations:
         - operator: Exists

--- a/swiss-army-knife/overlaytest.sh
+++ b/swiss-army-knife/overlaytest.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-DNS_CHECK=false
+DNS_TEST=false
+NAMESPACE=default
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --dns-check)
-      DNS_CHECK=true
+    --dns-test)
+      DNS_TEST=true
       shift
       ;;
     *)
@@ -16,53 +17,63 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo "=> Start network overlay, DNS, and API test"
+echo "=> Start network overlay and DNS test"
+if $DNS_TEST
+  then
+    DNS_PASS=0; DNS_FAIL=0
+  else
+    echo "DNS tests are skipped. Use --dns-check to enable."
+fi
+echo
+NET_PASS=0; NET_FAIL=0
 
-kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.metadata.name}{" "}{@.spec.nodeName}{" "}{@.status.podIP}{"\n"}{end}' | sort -k2 |
 while read spod shost sip
 do
   echo "Testing pod $spod on node $shost with IP $sip"
 
   # Overlay network test
   echo "  => Testing overlay network connectivity"
-  kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.status.podIP}{" "}{@.spec.nodeName}{"\n"}{end}' | sort -k2 |
-  while read tip thost
+    while read tip thost
   do
     if [[ ! $shost == $thost ]]; then
-      kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "ping -c2 $tip > /dev/null 2>&1"
+      kubectl -n $NAMESPACE exec $spod -c overlaytest -- /bin/sh -c "ping -c2 $tip > /dev/null 2>&1"
       RC=$?
       if [ $RC -ne 0 ]; then
-        echo "    FAIL: $spod on $shost cannot reach pod IP $tip on $thost"
+        ((NET_FAIL+=1)); echo "    FAIL: $spod on $shost cannot reach pod IP $tip on $thost"
       else
-        echo "    PASS: $spod on $shost can reach pod IP $tip on $thost"
+        ((NET_PASS+=1)); echo "    PASS: $spod on $shost can reach pod IP $tip on $thost"
       fi
     fi
-  done
+  done < <(kubectl get pods -n $NAMESPACE -l name=overlaytest -o jsonpath='{range .items[*]}{@.status.podIP}{" "}{@.spec.nodeName}{"\n"}{end}' | sort -k2)
 
-  if $DNS_CHECK; then
+  if $DNS_TEST; then
     # Internal DNS test
-    echo "  => Testing internal DNS"
-    kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "nslookup kubernetes.default > /dev/null 2>&1"
+    echo "  => Testing DNS"
+    kubectl -n $NAMESPACE exec $spod -c overlaytest -- /bin/sh -c "nslookup kubernetes.default > /dev/null 2>&1"
     RC=$?
     if [ $RC -ne 0 ]; then
-      echo "    FAIL: $spod cannot resolve internal DNS for 'kubernetes.default'"
+      ((DNS_FAIL+=1)); echo "    FAIL: $spod cannot resolve internal DNS for 'kubernetes.default'"
     else
-      echo "    PASS: $spod can resolve internal DNS for 'kubernetes.default'"
+      ((DNS_PASS+=1)); echo "    PASS: $spod can resolve internal DNS for 'kubernetes.default'"
     fi
 
     # External DNS test
-    echo "  => Testing external DNS"
-    kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "nslookup rancher.com > /dev/null 2>&1"
+    kubectl -n $NAMESPACE exec $spod -c overlaytest -- /bin/sh -c "nslookup rancher.com > /dev/null 2>&1"
     RC=$?
     if [ $RC -ne 0 ]; then
-      echo "    FAIL: $spod cannot resolve external DNS for 'rancher.com'"
+      ((DNS_FAIL+=1)); echo "    FAIL: $spod cannot resolve external DNS for 'rancher.com'"
     else
-      echo "    PASS: $spod can resolve external DNS for 'rancher.com'"
+      ((DNS_PASS+=1)); echo "    PASS: $spod can resolve external DNS for 'rancher.com'"
     fi
-  else
-    echo "  => DNS checks are skipped. Use --dns-check to enable."
   fi
+  echo
 
-done
+done < <(kubectl get pods -n $NAMESPACE -l name=overlaytest -o jsonpath='{range .items[*]}{@.metadata.name}{" "}{@.spec.nodeName}{" "}{@.status.podIP}{"\n"}{end}' | sort -k2)
 
-echo "=> End network overlay, DNS, and API test"
+NET_TOTAL=$(($NET_PASS + $NET_FAIL))
+echo "=> Network [$NET_PASS / $NET_TOTAL]"
+if $DNS_TEST; then
+  DNS_TOTAL=$(($DNS_PASS + $DNS_FAIL))
+  echo "=> DNS     [$DNS_PASS / $DNS_TOTAL]"
+fi
+echo; echo "=> End network overlay and DNS test"

--- a/swiss-army-knife/overlaytest.sh
+++ b/swiss-army-knife/overlaytest.sh
@@ -1,19 +1,68 @@
 #!/bin/bash
-echo "=> Start network overlay test"
-  kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.metadata.name}{" "}{@.spec.nodeName}{"\n"}{end}' | sort -k2 |
-  while read spod shost
-    do kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.status.podIP}{" "}{@.spec.nodeName}{"\n"}{end}' | sort -k2 |
-    while read tip thost
-      do
-        if [[ ! $shost == $thost ]]
-        then
-          kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "ping -c2 $tip > /dev/null 2>&1"
-          RC=$?
-          if [ $RC -ne 0 ]
-            then echo FAIL: $spod on $shost cannot reach pod IP $tip on $thost
-            else echo $shost can reach $thost
-          fi
-        fi
-    done
+
+DNS_CHECK=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dns-check)
+      DNS_CHECK=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+echo "=> Start network overlay, DNS, and API test"
+
+kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.metadata.name}{" "}{@.spec.nodeName}{" "}{@.status.podIP}{"\n"}{end}' | sort -k2 |
+while read spod shost sip
+do
+  echo "Testing pod $spod on node $shost with IP $sip"
+
+  # Overlay network test
+  echo "  => Testing overlay network connectivity"
+  kubectl get pods -l name=overlaytest -o jsonpath='{range .items[*]}{@.status.podIP}{" "}{@.spec.nodeName}{"\n"}{end}' | sort -k2 |
+  while read tip thost
+  do
+    if [[ ! $shost == $thost ]]; then
+      kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "ping -c2 $tip > /dev/null 2>&1"
+      RC=$?
+      if [ $RC -ne 0 ]; then
+        echo "    FAIL: $spod on $shost cannot reach pod IP $tip on $thost"
+      else
+        echo "    PASS: $spod on $shost can reach pod IP $tip on $thost"
+      fi
+    fi
   done
-echo "=> End network overlay test"
+
+  if $DNS_CHECK; then
+    # Internal DNS test
+    echo "  => Testing internal DNS"
+    kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "nslookup kubernetes.default > /dev/null 2>&1"
+    RC=$?
+    if [ $RC -ne 0 ]; then
+      echo "    FAIL: $spod cannot resolve internal DNS for 'kubernetes.default'"
+    else
+      echo "    PASS: $spod can resolve internal DNS for 'kubernetes.default'"
+    fi
+
+    # External DNS test
+    echo "  => Testing external DNS"
+    kubectl --request-timeout='10s' exec $spod -c overlaytest -- /bin/sh -c "nslookup rancher.com > /dev/null 2>&1"
+    RC=$?
+    if [ $RC -ne 0 ]; then
+      echo "    FAIL: $spod cannot resolve external DNS for 'rancher.com'"
+    else
+      echo "    PASS: $spod can resolve external DNS for 'rancher.com'"
+    fi
+  else
+    echo "  => DNS checks are skipped. Use --dns-check to enable."
+  fi
+
+done
+
+echo "=> End network overlay, DNS, and API test"


### PR DESCRIPTION
Refactor overlaytest.sh to enhance network overlay test to add DNS testing capabilities

- Added support for DNS checks via '--dns-check' argument (Off by default)
- Improved output messages for better clarity on test results
- Consolidated pod information retrieval in one command for efficiency
- Enhanced error handling for DNS resolution tests