### PR TITLE
logs-collector: add volumeattachment CRDs

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -590,7 +590,7 @@ k3s-k8s() {
   if [[ ${K3S_SERVER} && ! ${API_SERVER_OFFLINE} ]]; then
     unset KUBECONFIG
     k3s kubectl api-resources > $TMPDIR/${DISTRO}/kubectl/api-resources 2>&1
-    K3S_OBJECTS=(clusterroles clusterrolebindings crds mutatingwebhookconfigurations namespaces nodes pv validatingwebhookconfigurations)
+    K3S_OBJECTS=(clusterroles clusterrolebindings crds mutatingwebhookconfigurations namespaces nodes pv validatingwebhookconfigurations volumeattachments)
     K3S_OBJECTS_NAMESPACED=(apiservices configmaps cronjobs deployments daemonsets endpoints events helmcharts hpa ingress jobs leases networkpolicies pods pvc replicasets roles rolebindings statefulsets)
     for OBJECT in "${K3S_OBJECTS[@]}"; do
       k3s kubectl get ${OBJECT} -o wide > $TMPDIR/${DISTRO}/kubectl/${OBJECT} 2>&1
@@ -657,7 +657,7 @@ rke2-k8s() {
   if [[ ${RKE2_SERVER} && ! ${API_SERVER_OFFLINE} ]]; then
     KUBECONFIG=/etc/rancher/${DISTRO}/rke2.yaml
     ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG api-resources > $TMPDIR/${DISTRO}/kubectl/api-resources 2>&1
-    RKE2_OBJECTS=(clusterroles clusterrolebindings crds mutatingwebhookconfigurations namespaces nodes pv validatingwebhookconfigurations)
+    RKE2_OBJECTS=(clusterroles clusterrolebindings crds mutatingwebhookconfigurations namespaces nodes pv validatingwebhookconfigurations volumeattachments)
     RKE2_OBJECTS_NAMESPACED=(apiservices configmaps cronjobs deployments daemonsets endpoints events helmcharts hpa ingress jobs leases networkpolicies pods pvc replicasets roles rolebindings statefulsets)
     for OBJECT in "${RKE2_OBJECTS[@]}"; do
       ${RKE2_DATA_DIR}/bin/kubectl --kubeconfig=$KUBECONFIG get ${OBJECT} -o wide > $TMPDIR/${DISTRO}/kubectl/${OBJECT} 2>&1


### PR DESCRIPTION
    - Harvester team suggest support to use this tool to collect the guest cluster infomation (usually rke2/k3s k8s) for investigation. The volumeattachment info would help us to know the volume status on that time.