### PR TITLE
<fix> changed endpoint, fixed dir, added -s flag and new line

### DIFF
--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -120,7 +120,8 @@ collect() {
         echo
 
         techo Getting metrics for Rancher
-        kubectl -n $NAMESPACE exec $pod -c ${CONTAINER} -- bash -c 'curl -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k https://localhost/metrics' >${TMPDIR}$pod-metrics.txt
+        kubectl exec -n $NAMESPACE $pod -c ${CONTAINER} -- bash -c 'curl -s -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k https://127.0.0.1/metrics' >${TMPDIR}/$pod-metrics.txt
+        echo
       fi
 
       techo Getting rancher-event-logs for $pod


### PR DESCRIPTION
found an instance where the metrics would not be returned again localhost, but to 127.0.0.1. fixed the script to reflect that
directory was missing a / so the data was not being correctly collected
added a silent flag to the curl
added an extra blank line for readability

@aruiz14 fyi