### PR TITLE
Add hw collect with dmidecode

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -249,7 +249,9 @@ system-all() {
   if $(command -v conntrack >/dev/null 2>&1); then
     conntrack -S > $TMPDIR/systeminfo/conntrack
   fi
-
+  if $(command -v dmidecode >/dev/null 2>&1); then
+    dmidecode > $TMPDIR/systeminfo/dmidecode
+  fi
 }
 
 system-ubuntu() {


### PR DESCRIPTION
Execute dmidecode command in order to gather some HW information of the underlying HW as it can helps in the troubleshooting.