### PR TITLE
Update deploy.yaml

### DIFF
--- a/collection/rancher/v2.x/systems-information-v2/deploy.yaml
+++ b/collection/rancher/v2.x/systems-information-v2/deploy.yaml
@@ -19,7 +19,7 @@ spec:
           echo "Rancher version: $(kubectl get settings.management.cattle.io server-version --no-headers -o custom-columns=version:value)";
           echo "Rancher id: $(kubectl get settings.management.cattle.io install-uuid --no-headers -o custom-columns=id:value)";
           echo;
-          kubectl get clusters.management.cattle.io -o custom-columns=Cluster\ Id:metadata.name,Name:spec.displayName,K8s\ Version:status.version.gitVersion,Provider:status.driver,Created:metadata.creationTimestamp,Nodes:status.appliedSpec.rancherKubernetesEngineConfig.nodes[*].address;
+          kubectl get clusters.management.cattle.io -o custom-columns=Cluster\ Id:metadata.name,Name:spec.displayName,K8s\ Version:status.version.gitVersion,Provider:status.provider,Created:metadata.creationTimestamp,Nodes:status.appliedSpec.rancherKubernetesEngineConfig.nodes[*].address;
           CLUSTER_IDS=$(kubectl get cluster.management.cattle.io --no-headers -o custom-columns=id:metadata.name);
           for ID in $CLUSTER_IDS; do
             CLUSTER_NAME=$(kubectl get cluster.management.cattle.io ${ID} --no-headers -o custom-columns=name:spec.displayName);
@@ -28,7 +28,7 @@ spec:
             echo;
             echo '--------------------------------------------------------------------------------';
             echo "Cluster: ${CLUSTER_NAME} (${ID})";
-            kubectl get nodes.management.cattle.io -n ${ID} -o custom-columns=Node\ Id:metadata.name,Address:status.internalNodeStatus.addresses[*].address,Role:status.rkeNode.role[*],CPU:status.internalNodeStatus.capacity.cpu,RAM:status.internalNodeStatus.capacity.memory,OS:status.dockerInfo.OperatingSystem,Docker\ Version:status.dockerInfo.ServerVersion,Created:metadata.creationTimestamp;
+             kubectl get nodes.management.cattle.io -n ${ID} -o custom-columns=Node\ Id:metadata.name,Address:status.internalNodeStatus.addresses[*].address,etcd:spec.etcd,Control\ Plane:spec.controlPlane,Worker:spec.worker,CPU:status.internalNodeStatus.capacity.cpu,RAM:status.internalNodeStatus.capacity.memory,OS:status.internalNodeStatus.nodeInfo.osImage,Container\ Runtime\ Version:status.internalNodeStatus.nodeInfo.containerRuntimeVersion,Created:metadata.creationTimestamp;
             echo "Node count: ${NODE_COUNT}";
           done;
           echo '--------------------------------------------------------------------------------';


### PR DESCRIPTION
Fixes the Provider to show status.provider rather than status.driver Splits node roles out to also show for k3s/rke2
Shows OS for k3s/rke2 nodes
Shows CRI version instead of just Docker version since k3s/rke2 uses containerd