### PR TITLE
Typo in flag --private-registry-secret-user

### DIFF
--- a/collection/rancher/v2.x/supportability-review/README.md
+++ b/collection/rancher/v2.x/supportability-review/README.md
@@ -121,7 +121,7 @@ export SR_COLLECT_CLUSTER_INFO_DUMP=1
 ```shell
 ./collect.sh \
   --private-registry=$PRIVATE_REGISTRY \
-  --private-registry-secret-user=<user name> \
+  --private-registry-secret-username=<user name> \
   --private-registry-secret-password=<password>
 ```
 


### PR DESCRIPTION
Typo in flag: `--private-registry-secret-user` is incorrectly typed.
It should be: `--private-registry-secret-username`

Link to Code/Repo:
[GitHub Repo](https://github.com/rancher/supportability-review/blob/5edd6821794438528576ed6902cbdb92114e48b8/01_data_collection/collect_info_from_rancher_setup.py#L1156)