### PR TITLE
Remove wait for iptables NFT backend

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -302,16 +302,12 @@ networking() {
   mkdir -p "${TMPDIR}/networking"
   iptables-save > "${TMPDIR}/networking/iptablessave" 2>&1
   ip6tables-save > "${TMPDIR}/networking/ip6tablessave" 2>&1
-  if [ ! "${OSRELEASE}" = "sles" ]
-    then
-      IPTABLES_FLAGS="--wait 1"
-  fi
-  iptables "$IPTABLES_FLAGS" --numeric --verbose --list --table mangle > "${TMPDIR}/networking/iptablesmangle" 2>&1
-  iptables "$IPTABLES_FLAGS" --numeric --verbose --list --table nat > "${TMPDIR}/networking/iptablesnat" 2>&1
-  iptables "$IPTABLES_FLAGS" --numeric --verbose --list > "${TMPDIR}/networking/iptables" 2>&1
-  ip6tables "$IPTABLES_FLAGS" --numeric --verbose --list --table mangle > "${TMPDIR}/networking/ip6tablesmangle" 2>&1
-  ip6tables "$IPTABLES_FLAGS" --numeric --verbose --list --table nat > "${TMPDIR}/networking/ip6tablesnat" 2>&1
-  ip6tables "$IPTABLES_FLAGS" --numeric --verbose --list > "${TMPDIR}/networking/ip6tables" 2>&1
+  iptables --numeric --verbose --list --table mangle > "${TMPDIR}/networking/iptablesmangle" 2>&1
+  iptables --numeric --verbose --list --table nat > "${TMPDIR}/networking/iptablesnat" 2>&1
+  iptables --numeric --verbose --list > "${TMPDIR}/networking/iptables" 2>&1
+  ip6tables --numeric --verbose --list --table mangle > "${TMPDIR}/networking/ip6tablesmangle" 2>&1
+  ip6tables --numeric --verbose --list --table nat > "${TMPDIR}/networking/ip6tablesnat" 2>&1
+  ip6tables --numeric --verbose --list > "${TMPDIR}/networking/ip6tables" 2>&1
   if command -v nft >/dev/null 2>&1; then
     nft list ruleset  > "${TMPDIR}/networking/nft_ruleset" 2>&1
   fi


### PR DESCRIPTION
With broad adoption of NFT backend in supported distro's, the `--wait` flag is no longer necessary.

Tested on RKE2/Ubuntu