### PR TITLE
Add start day support for collection of RKE2 agent/server logs

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -713,7 +713,7 @@ rke2-k8s() {
     do
       if [ -d "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs/" ]; then
         mkdir -p "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs"
-        find "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs" -mtime -"${START_DAY}" -type f -exec cp -p {} "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs/" \;
+        find "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs" "${FIND_FLAG}" -type f -exec cp -p {} "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs/" \;
       fi
   done
 
@@ -1364,6 +1364,7 @@ while getopts "c:d:s:e:S:E:r:fpoh" opt; do
       START_DAY="$OPTARG"
       START=$(date -d "-$OPTARG days" '+%Y-%m-%d')
       SINCE_FLAG=(--since "$START")
+      FIND_FLAG=(-mtime -"${START_DAY}")
       techo "Logging since $START"
       ;;
     e)

--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -712,7 +712,8 @@ rke2-k8s() {
   for RKE2_LOG_DIR in agent server
     do
       if [ -d "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs/" ]; then
-        cp -rp "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs/" "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs"
+        mkdir -p "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs"
+        find "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs" -mtime -"${START_DAY}" -type f -exec cp -p {} "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs/" \;
       fi
   done
 


### PR DESCRIPTION
If a start day (eg, `-s 1`) is provided, only copy the RKE2 server/agent logs from that period