### PR TITLE
Fix collection of RKE2 config files

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -499,7 +499,7 @@ rke2-logs() {
     then
       for _FILE in "/etc/rancher/${DISTRO}/config.yaml.d/"*
         do
-          grep -Ev "token|access-key|secret-key" "/etc/rancher/${DISTRO}/config.yaml.d/$_FILE" >& "${TMPDIR}/${DISTRO}/$_FILE"
+          grep -Ev "token|access-key|secret-key" $_FILE >& "${TMPDIR}/${DISTRO}/$(basename $_FILE)"
       done
   fi
 


### PR DESCRIPTION
Fix the collection of RKE2 config files, the following error was seen testing the script due to the full path being used in the redirect

```bash
  [ ... ]
2025-07-16 01:42:07: Collecting rke2 info
main: line 502: /tmp/tmp.e8u1wJMKel/d-ingres-test-cp-6mkn6-pk4kn-2025-07-16_01_40_56/rke2//etc/rancher/rke2/config.yaml.d/50-rancher.yaml: No such file or directory
main: line 502: /tmp/tmp.e8u1wJMKel/d-ingres-test-cp-6mkn6-pk4kn-2025-07-16_01_40_56/rke2//etc/rancher/rke2/config.yaml.d/99-ingress.yaml: No such file or directory
2025-07-16 01:42:11: Collecting rke2 cluster logs
```