### PR TITLE
Add default start day to reduce collection size of RKE2/k3s logs

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -708,7 +708,8 @@ rke2-k8s() {
   for RKE2_LOG_DIR in agent server
     do
       if [ -d "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs/" ]; then
-        cp -rp "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs/" "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs"
+        mkdir -p "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs"
+        find "${RKE2_DATA_DIR}/${RKE2_LOG_DIR}/logs" -mtime -"${START_DAYS:=$VAR_LOG_DAYS}" -type f -exec cp -p {} "${TMPDIR}/${DISTRO}/${RKE2_LOG_DIR}-logs/" \;
       fi
   done
 


### PR DESCRIPTION
Reduce RKE2/k3s log collection sizes to 7 days by default:
 - RKE2 reduce agent/server logs
 - RKE2/k3s reduce pod logs

This can be overriden with the `-s` flag or by editing the `DEFAULT_LOG_DAYS` value in the script