### PR TITLE
Update rancher2_logs_collector.sh

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -388,10 +388,10 @@ provisioning-crds() {
           CRDS=("clusters.management.cattle.io" "nodes.management.cattle.io" "custommachines.rke.cattle.io" "etcdsnapshots.rke.cattle.io" "rkebootstraps.rke.cattle.io" "rkebootstraptemplates.rke.cattle.io" "rkeclusters.rke.cattle.io" "rkecontrolplanes.rke.cattle.io" "clusters.provisioning.cattle.io" "amazonec2machines.rke-machine.cattle.io" "amazonec2machinetemplates.rke-machine.cattle.io" "azuremachines.rke-machine.cattle.io" "azuremachinetemplates.rke-machine.cattle.io" "digitaloceanmachines.rke-machine.cattle.io" "digitaloceanmachinetemplates.rke-machine.cattle.io" "harvestermachines.rke-machine.cattle.io" "harvestermachinetemplates.rke-machine.cattle.io" "linodemachines.rke-machine.cattle.io" "linodemachinetemplates.rke-machine.cattle.io" "vmwarevspheremachines.rke-machine.cattle.io" "vmwarevspheremachinetemplates.rke-machine.cattle.io" "amazonec2configs.rke-machine-config.cattle.io" "azureconfigs.rke-machine-config.cattle.io" "digitaloceanconfigs.rke-machine-config.cattle.io" "harvesterconfigs.rke-machine-config.cattle.io" "linodeconfigs.rke-machine-config.cattle.io" "vmwarevsphereconfigs.rke-machine-config.cattle.io")
 
           for item in "${CRDS[@]}"; do
-            "${ctlcmd}" get "$item" -o yaml -A > "${TMPDIR}/${DISTRO}/kubectl/rancher-prov/${item}" 2>&1
+            ${ctlcmd} get "$item" -o yaml -A > "${TMPDIR}/${DISTRO}/kubectl/rancher-prov/${item}" 2>&1
           done
 
-          "$ctlcmd" get configmap cattle-controllers -n kube-system -o yaml > "${TMPDIR}/${DISTRO}/kubectl/rancher-prov/cattle-controller-cfgmap" 2>&1
+          $ctlcmd get configmap cattle-controllers -n kube-system -o yaml > "${TMPDIR}/${DISTRO}/kubectl/rancher-prov/cattle-controller-cfgmap" 2>&1
       fi
   fi
 


### PR DESCRIPTION
Removed quotes around $ctlcmd when executing, so the command and its arguments are split correctly by the shell.