### PR TITLE
Refine rke2-server logic and align some commands with rbac changes

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -607,6 +607,7 @@ k3s-k8s() {
     k3s kubectl --kubeconfig="$KUBECONFIG" get pods -o wide --all-namespaces > "${TMPDIR}/${DISTRO}/kubectl/pods" 2>&1
     k3s kubectl --kubeconfig="$KUBECONFIG" api-resources > "${TMPDIR}/${DISTRO}/kubectl/api-resources" 2>&1
     k3s kubectl --kubeconfig="$KUBECONFIG" version > "${TMPDIR}/${DISTRO}/kubectl/version" 2>&1
+    KUBECONFIG=/var/lib/rancher/${DISTRO}/agent/kubeproxy.kubeconfig
     k3s kubectl --kubeconfig="$KUBECONFIG" get svc -o wide --all-namespaces > "${TMPDIR}/${DISTRO}/kubectl/services" 2>&1
   fi
 


### PR DESCRIPTION
- Collect pod logs from the filesystem if kube-apiserver is offline, this helps when the node is a server and local pod logs can still be collected as an agent
- Shift kubectl output for pods and nodes to only run when it's is a server node