### PR TITLE
Check for a kubelet container before detecting RKE1

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -248,7 +248,7 @@ system-all() {
     sysctl -a > "${TMPDIR}/systeminfo/sysctla" 2>/dev/null
   fi
   if command -v systemctl >/dev/null 2>&1; then
-    systemctl list-units > "${TMPDIR}/systeminfo/systemd-units" 2>&1
+    systemctl list-units --all > "${TMPDIR}/systeminfo/systemd-units" 2>&1
   fi
   if command -v systemctl >/dev/null 2>&1; then
     systemctl list-unit-files > "${TMPDIR}/systeminfo/systemd-unit-files" 2>&1
@@ -844,7 +844,7 @@ journald-log() {
   techo "Collecting system logs from journald"
   mkdir -p "${TMPDIR}/journald"
   for JOURNALD_LOG in "${JOURNALD_LOGS[@]}"; do
-    if grep "$JOURNALD_LOG.service" "${TMPDIR}/systeminfo/systemd-units" > /dev/null 2>&1; then
+    if grep "$JOURNALD_LOG.service" "${TMPDIR}/systeminfo/systemd-unit-files" > /dev/null 2>&1; then
       "${JOURNALCTL_CMD[@]}" --unit="$JOURNALD_LOG" > "${TMPDIR}/journald/$JOURNALD_LOG"
     fi
   done


### PR DESCRIPTION
Resolves #409 

Confirms that the kubelet container exists (in any state) before RKE1 auto detection, to avoid the scenario where RKE2/k3s is not completely installed, but docker is running

As RKE1 is EOL this basic check should be adequate, if needed the -d flag can be used to override this, for example in a scenario where an RKE1 node wasn't provisioned fully and the kubelet doesn't exist