### PR TITLE
Correct free output filename

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -212,7 +212,7 @@ system-all() {
       cp -p /run/systemd/resolve/resolv.conf "${TMPDIR}/systeminfo/systemd-resolved" 2>&1
   fi
   date 2>&1 | tee -a "${TMPDIR}/systeminfo/date" "${TMPDIR}/versions" >/dev/null
-  free -h 2>&1 | tee -a "${TMPDIR}/systeminfo/memory" "${TMPDIR}/versions" >/dev/null
+  free -h 2>&1 | tee -a "${TMPDIR}/systeminfo/freeh" >/dev/null
   uptime > "${TMPDIR}/systeminfo/uptime" 2>&1
   dmesg -T > "${TMPDIR}/systeminfo/dmesg" 2>&1
   df -h > "${TMPDIR}/systeminfo/dfh" 2>&1


### PR DESCRIPTION
Fix what appears to be a accidental rename of `free` output to "memory", also remove it from the versions output