### PR TITLE
Fix supply chain risks in Dockerfiles and scripts

### DIFF
--- a/bad-ingress-scanner/Dockerfile
+++ b/bad-ingress-scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214
 MAINTAINER Matthew Mattox <matt.mattox@suse.com>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,9 +9,13 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ## Install kubectl
-RUN curl -kLO "https://storage.googleapis.com/kubernetes-release/release/$(curl -ks https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
-chmod u+x kubectl && \
-mv kubectl /usr/local/bin/kubectl
+ARG KUBECTL_VERSION=v1.35.3
+# renovate-local: kubectl-amd64=v1.35.3
+ARG KUBECTL_SUM_amd64=fd31c7d7129260e608f6faf92d5984c3267ad0b5ead3bced2fe125686e286ad6
+RUN curl -sSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    echo "${KUBECTL_SUM_amd64}  kubectl" | sha256sum -c - && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
 
 COPY *.sh /root/
 RUN chmod +x /root/*.sh

--- a/change-nodetemplate-owner/Dockerfile
+++ b/change-nodetemplate-owner/Dockerfile
@@ -1,8 +1,11 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214
 MAINTAINER patrick0057
 ENV TERM xterm
+ARG K8S_GPG_SUM=3ecc63922b7795eb23fdc449ff9396f9114cb3cf186d6f5b53ad4cc3ebfbb11f
 RUN apt-get update && apt-get install -y apt-transport-https curl gnupg2 && \
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+curl -sSLo /tmp/k8s-apt-key.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
+echo "${K8S_GPG_SUM}  /tmp/k8s-apt-key.gpg" | sha256sum -c - && \
+apt-key add /tmp/k8s-apt-key.gpg && rm /tmp/k8s-apt-key.gpg && \
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
 apt-get update && \
 apt-get install -y kubectl jq && \

--- a/collection/rancher/v2.x/systems-information/Dockerfile
+++ b/collection/rancher/v2.x/systems-information/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98
 MAINTAINER Rancher Support support@rancher.com
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,7 +8,13 @@ msmtp \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ##Installing kubectl
-RUN curl -k -LO https://storage.googleapis.com/kubernetes-release/release/`curl -k -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && mv kubectl /bin/kubectl && chmod +x /bin/kubectl
+ARG KUBECTL_VERSION=v1.35.3
+# renovate-local: kubectl-amd64=v1.35.3
+ARG KUBECTL_SUM_amd64=fd31c7d7129260e608f6faf92d5984c3267ad0b5ead3bced2fe125686e286ad6
+RUN curl -sSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    echo "${KUBECTL_SUM_amd64}  kubectl" | sha256sum -c - && \
+    chmod +x kubectl && \
+    mv kubectl /bin/kubectl
 
 ADD *.sh /usr/bin/
 RUN chmod +x /usr/bin/*.sh

--- a/rancher-metadata-syncer/Dockerfile
+++ b/rancher-metadata-syncer/Dockerfile
@@ -1,5 +1,5 @@
 ## Running builder to download metadata files
-FROM alpine AS builder
+FROM alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS builder
 MAINTAINER Matthew Mattox matt.mattox@suse.com
 RUN  apk update && apk add --update-cache \
     wget \
@@ -12,7 +12,7 @@ WORKDIR /root/
 RUN /usr/local/bin/download.sh
 
 ## Building webserver
-FROM httpd:alpine
+FROM httpd:alpine@sha256:8f26f33a7002658050e9ab2cd6b77502619dfc89d0a6ba2e9e4a202e0ef04596
 MAINTAINER Matthew Mattox matt.mattox@suse.com
 RUN  apk update && apk add --update-cache \
     wget \

--- a/rancher-metadata-syncer/download.sh
+++ b/rancher-metadata-syncer/download.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "Downloading kontainer-driver-metadata for v2.4"
-wget --no-check-certificate -O v2-4.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json
+wget -O v2-4.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json
 
 echo "Downloading kontainer-driver-metadata for v2.5"
-wget --no-check-certificate -O v2-5.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.5/data.json
+wget -O v2-5.json https://releases.rancher.com/kontainer-driver-metadata/release-v2.5/data.json


### PR DESCRIPTION
## Summary

Addresses supply chain security findings from the SCA scan (rancher/rancher-security#1647).

The real risks identified are not package version pinning but:
1. Downloading executables (kubectl, apt GPG keys) without checksum validation
2. `--no-check-certificate` disabling TLS verification in wget
3. Mutable base image tags that can be silently updated or replaced

## Changes

- **bad-ingress-scanner/Dockerfile** — Pin `ubuntu:20.04` to digest; replace dynamic kubectl download with pinned `v1.35.3` + SHA256 checksum validation
- **change-nodetemplate-owner/Dockerfile** — Pin `ubuntu:20.04` to digest; download Kubernetes apt GPG key separately and validate SHA256 before adding to keyring
- **collection/rancher/v2.x/systems-information/Dockerfile** — Pin `ubuntu:18.04` to digest; same kubectl pin + checksum as above
- **rancher-metadata-syncer/Dockerfile** — Pin both build stages (`alpine`, `httpd:alpine`) to digest
- **rancher-metadata-syncer/download.sh** — Remove `--no-check-certificate` from both `wget` calls

## Verification

Built all four images locally with `docker build --no-cache` to confirm checksum validation passes. A tampered checksum causes the build to fail at the `sha256sum -c` step, confirming the guard is active.