### PR TITLE
Update troubleshooting-scripts: RKE2/k3s support, deprecate RKE1

### DIFF
--- a/troubleshooting-scripts/README.md
+++ b/troubleshooting-scripts/README.md
@@ -1,30 +1,30 @@
 # Troubleshooting Scripts
 
-## kube-scheduler
+Scripts support **RKE2** and **k3s**. RKE1 commands are preserved in deprecated sections within each README.
 
-### Finding the current leader
+## Contents
 
-Command(s): `curl -s https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/kube-scheduler/find-leader.sh | bash`
+| Directory | Description |
+|-----------|-------------|
+| [rke2-reference/](rke2-reference/README.md) | Quick reference: install, binaries, kubeconfig, crictl, logging |
+| [etcd/](etcd/README.md) | etcd health, status, maintenance, and direct key queries |
+| [kube-apiserver/](kube-apiserver/) | API server endpoint checks and responsiveness |
+| [kube-scheduler/](kube-scheduler/) | Find the active kube-scheduler leader |
+| [determine-leader/](determine-leader/) | Find the active Rancher leader pod |
 
-**Example Output**
+## Quick links
 
-```bash
-kube-scheduler is the leader on node a1ubk8slabl03
-```
+- etcd health check script (RKE2/k3s, auto-detecting):
+  ```bash
+  curl -s https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/etcd/check-endpoints.sh | sudo bash
+  ```
 
-## determine-leader
+- kube-scheduler leader:
+  ```bash
+  curl -s https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/kube-scheduler/find-leader.sh | bash
+  ```
 
-Command(s): `curl -s https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh | bash`
-
-**Example Output**
-
-```bash
-NAME                                    POD-IP         HOST-IP
-cattle-cluster-agent-776d795ff8-x77nq   10.42.0.93     10.10.100.83
-cattle-node-agent-4bsx6                 10.10.100.83   10.10.100.83
-rancher-54d47dc9cf-d4qt9                10.42.0.92     10.10.100.83
-rancher-54d47dc9cf-prn4d                10.42.0.90     10.10.100.83
-rancher-54d47dc9cf-rsn4g                10.42.0.91     10.10.100.83
-
-rancher-54d47dc9cf-prn4d is the leader in this Rancher instance
-```
+- Rancher leader pod:
+  ```bash
+  curl -s https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh | bash
+  ```

--- a/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
+++ b/troubleshooting-scripts/determine-leader/rancher2_determine_leader.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
-RANCHER_LEADER="$(kubectl -n kube-system get lease cattle-controllers -o json | jq -r '.spec.holderIdentity')"
+RANCHER_LEADER="$(kubectl -n kube-system get lease cattle-controllers \
+  -o jsonpath='{.spec.holderIdentity}' 2>/dev/null)"
+
+if [ -z "$RANCHER_LEADER" ]; then
+  echo "ERROR: Could not determine Rancher leader. Is Rancher running?" >&2
+  echo "  Verify the cattle-controllers Lease exists:" >&2
+  echo "    kubectl -n kube-system get lease cattle-controllers" >&2
+  exit 1
+fi
+
 # Display Rancher Pods Information
-kubectl get pod -n cattle-system $RANCHER_LEADER -o custom-columns=NAME:.metadata.name,POD-IP:.status.podIP,HOST-IP:.status.hostIP
-printf "\n$RANCHER_LEADER is the leader in this Rancher instance\n"
+kubectl get pod -n cattle-system "$RANCHER_LEADER" \
+  -o custom-columns=NAME:.metadata.name,POD-IP:.status.podIP,HOST-IP:.status.hostIP
+
+printf "\n%s is the leader in this Rancher instance\n" "$RANCHER_LEADER"

--- a/troubleshooting-scripts/etcd/README.md
+++ b/troubleshooting-scripts/etcd/README.md
@@ -1,69 +1,256 @@
-# etcd-troubleshooting
+# etcd Troubleshooting
 
-## Check etcd members
-Command(s): `docker exec etcd etcdctl member list`
+Commands for inspecting etcd health, status, and data on RKE2 and k3s clusters.
+Verified on RKE2 v1.33.7.
 
-**Example Output of a healthy cluster**
+---
+
+## Section 1: Via `kubectl exec` (requires kubeconfig)
+
+Iterate over all etcd pods:
+
 ```bash
-2f080bc6ec98f39b, started, etcd-a1ubrkeat03, https://172.27.5.33:2380, https://172.27.5.33:2379,https://172.27.5.33:4001, false
-9d7204f89b221ba3, started, etcd-a1ubrkeat01, https://172.27.5.31:2380, https://172.27.5.31:2379,https://172.27.5.31:4001, false
-bd37bc0dc2e990b6, started, etcd-a1ubrkeat02, https://172.27.5.32:2380, https://172.27.5.32:2379,https://172.27.5.32:4001, false
+for etcdpod in $(kubectl -n kube-system get pod -l component=etcd \
+  --no-headers -o custom-columns=NAME:.metadata.name); do
+  echo "=== $etcdpod ==="
+  kubectl -n kube-system exec "$etcdpod" -- etcdctl \
+    --cert  /var/lib/rancher/rke2/server/tls/etcd/server-client.crt \
+    --key   /var/lib/rancher/rke2/server/tls/etcd/server-client.key \
+    --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt \
+    COMMAND
+done
 ```
 
-## Check etcd endpoints
-Command(s): `curl https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/etcd/check-endpoints.sh | bash `
+Replace `COMMAND` with any of:
+- `check perf`
+- `endpoint status --cluster --write-out=table`
+- `endpoint health --cluster --write-out=table`
+- `member list --write-out=table`
+- `alarm list`
+- `defrag --cluster`
 
-**Example Output of a healthy cluster**
+> **Note:** `curl` is not present in the etcd container since k8s 1.28.
+> Use `etcdctl endpoint health` for health checks.
+> Use `curl http://127.0.0.1:2381/metrics` from the **host** for metrics (see Section 2).
+
+---
+
+## Section 2: On the etcd host via `crictl exec`
+
+Works on k8s ≥ 1.28 (no `/bin/sh` needed — `crictl exec` runs the binary directly).
+
+### Setup
+
+**RKE2:**
+
 ```bash
-Validating connection to https://172.27.5.33:2379/health
-{"health":"true"}
-Validating connection to https://172.27.5.31:2379/health
-{"health":"true"}
-Validating connection to https://172.27.5.32:2379/health
-{"health":"true"}
+export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+CRICTL=/var/lib/rancher/rke2/bin/crictl
+CERT_DIR=/var/lib/rancher/rke2/server/tls/etcd
 ```
 
-## Check etcd logs
+**k3s:**
 
-`health check for peer xxx could not connect: dial tcp IP:2380: getsockopt: connection refused`
+```bash
+export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
+CRICTL=/var/lib/rancher/k3s/data/current/bin/crictl
+CERT_DIR=/var/lib/rancher/k3s/server/tls/etcd
+# Alternative: k3s etcdctl (no crictl wrapper needed)
+```
 
-A connection to the address shown on port 2380 cannot be established. Check if the etcd container is running on the host with the address shown.
+**Common variables:**
 
+```bash
+ETCD_CONTAINER=$($CRICTL ps --label io.kubernetes.container.name=etcd --quiet | head -1)
+CERT="$CERT_DIR/server-client.crt"
+KEY="$CERT_DIR/server-client.key"
+CA="$CERT_DIR/server-ca.crt"
+```
 
-`xxx is starting a new election at term x`
+### etcdctl commands
 
-The etcd cluster has lost it’s quorum and is trying to establish a new leader. This can happen when the majority of the nodes running etcd go down/unreachable.
+All commands follow this pattern:
 
+```bash
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  COMMAND
+```
 
-`connection error: desc = "transport: Error while dialing dial tcp 0.0.0.0:2379: i/o timeout"; Reconnecting to {0.0.0.0:2379 0 <nil>}`
+Replace `COMMAND` with:
 
-The host firewall is preventing network communication.
+```bash
+# Performance check
+check perf
 
+# Endpoint status (all members)
+endpoint status --cluster --write-out=table
 
-`rafthttp: request cluster ID mismatch`
+# Endpoint health (all members)
+endpoint health --cluster --write-out=table
 
-The node with the etcd instance logging `rafthttp: request cluster ID mismatch` is trying to join a cluster that has already been formed with another peer. The node should be removed from the cluster, and re-added.
+# Member list
+member list --write-out=table
 
+# List alarms
+alarm list
 
-`rafthttp: failed to find member`
+# Defragment all members
+defrag --cluster
+```
 
-The cluster state (`/var/lib/etcd`) contains wrong information to join the cluster. The node should be removed from the cluster, the state directory should be cleaned and the node should be re-added.
+### Compact with auto-revision
 
-## Enabling debug logging
-`curl -XPUT -d '{"Level":"DEBUG"}' --cacert $(docker exec etcd printenv ETCDCTL_CACERT) --cert $(docker exec etcd printenv ETCDCTL_CERT) --key $(docker exec etcd printenv ETCDCTL_KEY) https://localhost:2379/config/local/log`
+```bash
+REV=$($CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  endpoint status --write-out fields | grep "^Revision" | cut -d: -f2 | tr -d ' ')
 
-## Disabling debug logging
-`curl -XPUT -d '{"Level":"INFO"}' --cacert $(docker exec etcd printenv ETCDCTL_CACERT) --cert $(docker exec etcd printenv ETCDCTL_CERT) --key $(docker exec etcd printenv ETCDCTL_KEY) https://localhost:2379/config/local/log`
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  compact "$REV"
+```
 
-## Getting etcd metrics
-`curl -X GET --cacert $(docker exec etcd printenv ETCDCTL_CACERT) --cert $(docker exec etcd printenv ETCDCTL_CERT) --key $(docker exec etcd printenv ETCDCTL_KEY) https://localhost:2379/metrics`
+### Metrics and health (port 2381, plain HTTP — no certs)
 
+Port 2381 is etcd's `--listen-metrics-urls` and serves plain HTTP with no TLS.
+Port 2379 is gRPC-only and cannot be used with plain `curl`.
 
-**wal_fsync_duration_seconds (99% under 10 ms)**
+```bash
+# Health
+curl -sL http://127.0.0.1:2381/health
 
-A wal_fsync is called when etcd persists its log entries to disk before applying them.
+# Metrics
+curl -sL http://127.0.0.1:2381/metrics
 
+# Liveness / Readiness
+curl -sL http://127.0.0.1:2381/livez
+curl -sL http://127.0.0.1:2381/readyz
+```
 
-**backend_commit_duration_seconds (99% under 25 ms)**
+### Member connectivity check
 
-A backend_commit is called when etcd commits an incremental snapshot of its most recent changes to disk.
+Use `etcdctl` — the curl loop on port 2379 does not work (gRPC-only port):
+
+```bash
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  endpoint health --cluster --write-out=table
+```
+
+### Watch etcd changes
+
+```bash
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  watch --prefix /registry
+```
+
+### Query etcd keys
+
+```bash
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  get /registry --prefix=true --keys-only
+```
+
+### Key count per resource type (find bloated resources)
+
+```bash
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  get /registry --prefix=true --keys-only | grep -v '^$' | \
+  awk -F'/' '{ if ($3 ~ /cattle.io/) {h[$3"/"$4]++} else { h[$3]++ }} \
+  END { for(k in h) print h[k], k }' | sort -nr
+```
+
+### Enable/disable debug logging
+
+```bash
+# Enable
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  --endpoints https://127.0.0.1:2379 \
+  log-level debug
+
+# Disable
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  --endpoints https://127.0.0.1:2379 \
+  log-level info
+```
+
+---
+
+## Quick script
+
+`check-endpoints.sh` auto-detects RKE2 or k3s and runs health + status + members + alarms:
+
+```bash
+curl -s https://raw.githubusercontent.com/rancherlabs/support-tools/master/troubleshooting-scripts/etcd/check-endpoints.sh | sudo bash
+```
+
+---
+
+## Log message reference
+
+| Message | Meaning |
+|---------|---------|
+| `health check for peer xxx could not connect: dial tcp IP:2380` | etcd container not running on that peer, or port 2380 blocked |
+| `xxx is starting a new election at term x` | Cluster lost quorum; majority of etcd nodes down |
+| `connection error: i/o timeout … 0.0.0.0:2379` | Host firewall blocking etcd client port |
+| `rafthttp: request cluster ID mismatch` | Node trying to join wrong cluster — remove and re-add |
+| `rafthttp: failed to find member` | Stale cluster state in `/var/lib/etcd` — remove, clean, and re-add |
+
+---
+
+## Section 3: Deprecated — RKE1
+
+> RKE1 reached end-of-life. Commands below are preserved for reference only.
+
+```bash
+# List members
+docker exec etcd etcdctl member list
+
+# Print cert env vars
+docker exec etcd printenv ETCDCTL_CERT_FILE ETCDCTL_KEY_FILE ETCDCTL_CA_FILE
+
+# Cluster health (etcd v2)
+docker exec etcd etcdctl cluster-health
+
+# Endpoint health (etcd v3)
+docker exec etcd etcdctl endpoint health
+
+# Check endpoint connectivity (curl loop via appropriate/curl image)
+for endpoint in $(docker exec etcd /bin/sh -c "etcdctl member list | cut -d, -f5"); do
+  echo "Validating connection to ${endpoint}/health"
+  docker run --net=host \
+    -v $(docker inspect kubelet --format '{{ range .Mounts }}{{ if eq .Destination "/etc/kubernetes" }}{{ .Source }}{{ end }}{{ end }}')/ssl:/etc/kubernetes/ssl:ro \
+    appropriate/curl -s -w "\n" \
+    --cacert $(docker exec etcd printenv ETCDCTL_CACERT) \
+    --cert   $(docker exec etcd printenv ETCDCTL_CERT) \
+    --key    $(docker exec etcd printenv ETCDCTL_KEY) \
+    "${endpoint}/health"
+done
+
+# Enable debug logging (RKE1)
+curl -XPUT -d '{"Level":"DEBUG"}' \
+  --cacert $(docker exec etcd printenv ETCDCTL_CACERT) \
+  --cert   $(docker exec etcd printenv ETCDCTL_CERT) \
+  --key    $(docker exec etcd printenv ETCDCTL_KEY) \
+  https://localhost:2379/config/local/log
+
+# Disable debug logging (RKE1)
+curl -XPUT -d '{"Level":"INFO"}' \
+  --cacert $(docker exec etcd printenv ETCDCTL_CACERT) \
+  --cert   $(docker exec etcd printenv ETCDCTL_CERT) \
+  --key    $(docker exec etcd printenv ETCDCTL_KEY) \
+  https://localhost:2379/config/local/log
+
+# Get metrics (RKE1)
+curl -X GET \
+  --cacert $(docker exec etcd printenv ETCDCTL_CACERT) \
+  --cert   $(docker exec etcd printenv ETCDCTL_CERT) \
+  --key    $(docker exec etcd printenv ETCDCTL_KEY) \
+  https://localhost:2379/metrics
+```

--- a/troubleshooting-scripts/etcd/check-endpoints.sh
+++ b/troubleshooting-scripts/etcd/check-endpoints.sh
@@ -1,6 +1,72 @@
 #!/bin/bash
-for endpoint in $(docker exec etcd /bin/sh -c "etcdctl member list | cut -d, -f5");
-do
-  echo "Validating connection to ${endpoint}/health";
-  docker run --net=host -v $(docker inspect kubelet --format '{{ range .Mounts }}{{ if eq .Destination "/etc/kubernetes" }}{{ .Source }}{{ end }}{{ end }}')/ssl:/etc/kubernetes/ssl:ro appropriate/curl -s -w "\n" --cacert $(docker exec etcd printenv ETCDCTL_CACERT) --cert $(docker exec etcd printenv ETCDCTL_CERT) --key $(docker exec etcd printenv ETCDCTL_KEY) "${endpoint}/health";
-done
+# Check etcd health, status, members, and alarms on RKE2 or k3s clusters.
+# Must be run as root on a server/control-plane node.
+#
+# Usage: bash check-endpoints.sh
+
+set -euo pipefail
+
+detect_distro() {
+  # Detect by TLS cert directory — works on all RKE2 versions including v1.31+
+  # where etcdctl is no longer in the host bin directory.
+  if [ -d /var/lib/rancher/rke2/server/tls/etcd ]; then
+    echo "rke2"
+  elif [ -d /var/lib/rancher/k3s/server/tls/etcd ]; then
+    echo "k3s"
+  else
+    echo "unknown"
+  fi
+}
+
+DISTRO=$(detect_distro)
+
+if [ "$DISTRO" = "rke2" ]; then
+  export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+  CRICTL=/var/lib/rancher/rke2/bin/crictl
+  CERT_DIR=/var/lib/rancher/rke2/server/tls/etcd
+elif [ "$DISTRO" = "k3s" ]; then
+  export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
+  CRICTL=/var/lib/rancher/k3s/data/current/bin/crictl
+  CERT_DIR=/var/lib/rancher/k3s/server/tls/etcd
+else
+  echo "ERROR: Could not detect RKE2 or k3s installation." >&2
+  echo "  Expected one of:" >&2
+  echo "    /var/lib/rancher/rke2/server/tls/etcd" >&2
+  echo "    /var/lib/rancher/k3s/server/tls/etcd" >&2
+  exit 1
+fi
+
+ETCD_CONTAINER=$($CRICTL ps --label io.kubernetes.container.name=etcd --quiet 2>/dev/null | head -1)
+
+if [ -z "$ETCD_CONTAINER" ]; then
+  echo "ERROR: No running etcd container found." >&2
+  echo "  Verify etcd is running: $CRICTL ps -a" >&2
+  exit 1
+fi
+
+CERT="$CERT_DIR/server-client.crt"
+KEY="$CERT_DIR/server-client.key"
+CA="$CERT_DIR/server-ca.crt"
+
+echo "=== etcd endpoint health (distro: $DISTRO) ==="
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  endpoint health --cluster --write-out=table
+
+echo ""
+echo "=== etcd endpoint status ==="
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  endpoint status --cluster --write-out=table
+
+echo ""
+echo "=== etcd member list ==="
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  member list --write-out=table
+
+echo ""
+echo "=== etcd alarm list ==="
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  alarm list

--- a/troubleshooting-scripts/kube-apiserver/check_apiserver-to-etcd.sh
+++ b/troubleshooting-scripts/kube-apiserver/check_apiserver-to-etcd.sh
@@ -1,8 +1,54 @@
 #!/bin/bash
+# Check kube-apiserver connectivity to etcd on RKE2 or k3s clusters.
+# Must be run as root on a server/control-plane node.
+#
+# Usage: bash check_apiserver-to-etcd.sh
 
-for i in $(docker inspect kube-apiserver | grep -m 1 "\--etcd-servers" | grep -Po '(?<=https://)[^:]*')
-do
-  echo -n "Checking $i "
-  curl --cacert /etc/kubernetes/ssl/kube-ca.pem --cert /etc/kubernetes/ssl/kube-node.pem --key /etc/kubernetes/ssl/kube-node-key.pem https://"$i":2379/health
-  echo ""
-done
+set -euo pipefail
+
+detect_distro() {
+  if [ -d /var/lib/rancher/rke2/server/tls/etcd ]; then
+    echo "rke2"
+  elif [ -d /var/lib/rancher/k3s/server/tls/etcd ]; then
+    echo "k3s"
+  else
+    echo "unknown"
+  fi
+}
+
+DISTRO=$(detect_distro)
+
+if [ "$DISTRO" = "rke2" ]; then
+  export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+  CRICTL=/var/lib/rancher/rke2/bin/crictl
+  CERT_DIR=/var/lib/rancher/rke2/server/tls/etcd
+elif [ "$DISTRO" = "k3s" ]; then
+  export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
+  CRICTL=/var/lib/rancher/k3s/data/current/bin/crictl
+  CERT_DIR=/var/lib/rancher/k3s/server/tls/etcd
+else
+  echo "ERROR: Could not detect RKE2 or k3s installation." >&2
+  exit 1
+fi
+
+ETCD_CONTAINER=$($CRICTL ps --label io.kubernetes.container.name=etcd --quiet 2>/dev/null | head -1)
+
+if [ -z "$ETCD_CONTAINER" ]; then
+  echo "ERROR: No running etcd container found." >&2
+  exit 1
+fi
+
+CERT="$CERT_DIR/server-client.crt"
+KEY="$CERT_DIR/server-client.key"
+CA="$CERT_DIR/server-ca.crt"
+
+echo "=== etcd member list (distro: $DISTRO) ==="
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  member list --write-out=table
+
+echo ""
+echo "=== etcd endpoint status ==="
+$CRICTL exec "$ETCD_CONTAINER" etcdctl \
+  --cert "$CERT" --key "$KEY" --cacert "$CA" \
+  endpoint status --cluster --write-out=table

--- a/troubleshooting-scripts/kube-apiserver/check_endpoints.sh
+++ b/troubleshooting-scripts/kube-apiserver/check_endpoints.sh
@@ -5,7 +5,7 @@ EndPointIPs=`kubectl get endpoints kubernetes -o jsonpath='{.subsets[].addresses
 
 for EndPointIP in $EndPointIPs
 do
-  if kubectl get nodes --selector=node-role.kubernetes.io/controlplane=true -o jsonpath={.items[*].status.addresses[?\(@.type==\"InternalIP\"\)].address} | grep $EndPointIP > /dev/null
+  if kubectl get nodes --selector=node-role.kubernetes.io/control-plane=true -o jsonpath={.items[*].status.addresses[?\(@.type==\"InternalIP\"\)].address} | grep $EndPointIP > /dev/null
   then
     echo "Good - $EndPointIP"
   else

--- a/troubleshooting-scripts/kube-apiserver/responsiveness.sh
+++ b/troubleshooting-scripts/kube-apiserver/responsiveness.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-for cip in $(kubectl get nodes -l "node-role.kubernetes.io/controlplane=true" -o jsonpath='{range.items[*].status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}');
+for cip in $(kubectl get nodes -l "node-role.kubernetes.io/control-plane=true" -o jsonpath='{range.items[*].status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}');
 do
   kubectl --server https://${cip}:6443 get nodes -v6 2>&1| grep round_trippers;
 done

--- a/troubleshooting-scripts/kube-scheduler/find-leader.sh
+++ b/troubleshooting-scripts/kube-scheduler/find-leader.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
-NODE="$(kubectl -n kube-system get endpoints kube-scheduler -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io/leader}' | jq -r .holderIdentity | sed 's/_[^_]*$//')"
-echo "kube-scheduler is the leader on node $NODE"
+# Find the current kube-scheduler leader.
+# Uses Lease-based leader election (RKE2, k3s, k8s >= 1.20).
+# Verified working on RKE2 v1.33.7.
+#
+# Usage: bash find-leader.sh
+
+NODE=$(kubectl -n kube-system get lease kube-scheduler \
+  -o jsonpath='{.spec.holderIdentity}' 2>/dev/null | sed 's/_[^_]*$//')
+
+if [ -z "$NODE" ]; then
+  echo "ERROR: Could not determine kube-scheduler leader." >&2
+  echo "  Verify the kube-scheduler Lease exists:" >&2
+  echo "    kubectl -n kube-system get lease kube-scheduler" >&2
+  exit 1
+fi
+
+echo "kube-scheduler leader: $NODE"

--- a/troubleshooting-scripts/rke2-reference/README.md
+++ b/troubleshooting-scripts/rke2-reference/README.md
@@ -1,0 +1,173 @@
+# RKE2 Quick Reference
+
+Quick reference for common RKE2 operations on server/control-plane nodes.
+
+---
+
+## Install
+
+```bash
+curl -sL https://get.rke2.io | sh
+```
+
+Select a channel:
+
+```bash
+# Stable (default)
+curl -sL https://get.rke2.io | INSTALL_RKE2_CHANNEL=stable sh
+
+# Latest
+curl -sL https://get.rke2.io | INSTALL_RKE2_CHANNEL=latest sh
+
+# Pin to a specific version
+curl -sL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.27.5+rke2r1 sh
+```
+
+Enable and start:
+
+```bash
+systemctl enable --now rke2-server
+```
+
+---
+
+## Binary Locations
+
+All binaries live under `/var/lib/rancher/rke2/bin/`:
+
+```
+containerd
+containerd-shim-runc-v2
+crictl
+ctr
+kubectl
+kubelet
+runc
+```
+
+> **Note:** `etcdctl` is **not** present in this directory on RKE2 v1.31+.
+> It lives only inside the etcd container. Access it via `crictl exec` — see [etcd/README.md](../etcd/README.md).
+
+---
+
+## kubeconfig
+
+```bash
+export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+/var/lib/rancher/rke2/bin/kubectl get nodes
+```
+
+Or add to your shell profile:
+
+```bash
+echo 'export KUBECONFIG=/etc/rancher/rke2/rke2.yaml' >> ~/.bashrc
+echo 'export PATH=$PATH:/var/lib/rancher/rke2/bin' >> ~/.bashrc
+```
+
+---
+
+## containerd
+
+Socket location: `/run/k3s/containerd/containerd.sock`
+
+---
+
+## ctr
+
+```bash
+/var/lib/rancher/rke2/bin/ctr \
+  --address /run/k3s/containerd/containerd.sock \
+  --namespace k8s.io \
+  container ls
+```
+
+List images:
+
+```bash
+/var/lib/rancher/rke2/bin/ctr \
+  --address /run/k3s/containerd/containerd.sock \
+  --namespace k8s.io \
+  image ls
+```
+
+---
+
+## crictl
+
+Three equivalent ways to invoke crictl:
+
+**1. Via environment variable (recommended):**
+
+```bash
+export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+/var/lib/rancher/rke2/bin/crictl ps
+```
+
+**2. Via config flag:**
+
+```bash
+/var/lib/rancher/rke2/bin/crictl \
+  --config /var/lib/rancher/rke2/agent/etc/crictl.yaml ps
+```
+
+**3. Via socket flag:**
+
+```bash
+/var/lib/rancher/rke2/bin/crictl \
+  --runtime-endpoint unix:///run/k3s/containerd/containerd.sock ps -a
+```
+
+Common crictl commands:
+
+```bash
+# List running containers
+/var/lib/rancher/rke2/bin/crictl ps
+
+# List all containers (including stopped)
+/var/lib/rancher/rke2/bin/crictl ps -a
+
+# List pods
+/var/lib/rancher/rke2/bin/crictl pods
+
+# Pull/inspect images
+/var/lib/rancher/rke2/bin/crictl images
+/var/lib/rancher/rke2/bin/crictl inspecti <image-id>
+
+# Exec into a container (no shell required)
+/var/lib/rancher/rke2/bin/crictl exec <container-id> <command>
+
+# Container logs
+/var/lib/rancher/rke2/bin/crictl logs <container-id>
+```
+
+---
+
+## Logging
+
+```bash
+# Server service journal
+journalctl -f -u rke2-server
+
+# Agent service journal
+journalctl -f -u rke2-agent
+
+# containerd log
+/var/lib/rancher/rke2/agent/containerd/containerd.log
+
+# kubelet log
+/var/lib/rancher/rke2/agent/logs/kubelet.log
+```
+
+---
+
+## k3s Equivalents
+
+| Resource | RKE2 | k3s |
+|----------|------|-----|
+| TLS certs dir | `/var/lib/rancher/rke2/server/tls/` | `/var/lib/rancher/k3s/server/tls/` |
+| kubeconfig | `/etc/rancher/rke2/rke2.yaml` | `/etc/rancher/k3s/k3s.yaml` |
+| crictl binary | `/var/lib/rancher/rke2/bin/crictl` | `/var/lib/rancher/k3s/data/current/bin/crictl` |
+| crictl config | `/var/lib/rancher/rke2/agent/etc/crictl.yaml` | `/var/lib/rancher/k3s/agent/etc/crictl.yaml` |
+| containerd socket | `/run/k3s/containerd/containerd.sock` | `/run/k3s/containerd/containerd.sock` |
+| Service name | `rke2-server` | `k3s` |
+| etcdctl shortcut | *(use crictl exec)* | `k3s etcdctl` |

--- a/troubleshooting-scripts/rke2-reference/README.md
+++ b/troubleshooting-scripts/rke2-reference/README.md
@@ -37,6 +37,8 @@ All binaries live under `/var/lib/rancher/rke2/bin/`:
 
 ```
 containerd
+containerd-shim
+containerd-shim-runc-v1
 containerd-shim-runc-v2
 crictl
 ctr
@@ -52,12 +54,20 @@ runc
 
 ## kubeconfig
 
+Via environment variable:
+
 ```bash
 export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
 /var/lib/rancher/rke2/bin/kubectl get nodes
 ```
 
-Or add to your shell profile:
+Via inline flag (no env required):
+
+```bash
+/var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes
+```
+
+Add to your shell profile (persistent):
 
 ```bash
 echo 'export KUBECONFIG=/etc/rancher/rke2/rke2.yaml' >> ~/.bashrc
@@ -157,6 +167,33 @@ journalctl -f -u rke2-agent
 # kubelet log
 /var/lib/rancher/rke2/agent/logs/kubelet.log
 ```
+
+---
+
+## Systemd Service Files
+
+| File | Path |
+|------|------|
+| Server service unit | `/usr/local/lib/systemd/system/rke2-server.service` |
+| Agent service unit | `/usr/local/lib/systemd/system/rke2-agent.service` |
+| Server env override | `/etc/default/rke2-server` |
+| Agent env override | `/etc/default/rke2-agent` |
+
+Use the env override files to set or override RKE2 environment variables without editing the unit file directly (survives upgrades).
+
+---
+
+## Distribution Contents
+
+Scripts and configs installed alongside the RKE2 binary:
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `rke2-killall.sh` | `/usr/local/bin/rke2-killall.sh` | Stop all RKE2 processes and unmount volumes |
+| `rke2-uninstall.sh` | `/usr/local/bin/rke2-uninstall.sh` | Fully remove RKE2 from a Linux node |
+| `rke2-cis-sysctl.conf` | `/usr/local/lib/sysctl.d/60-rke2-cis.conf` | Kernel parameter overrides for CIS hardening |
+
+> **Warning:** `rke2-uninstall.sh` removes all RKE2 data and config — run only when decommissioning a node.
 
 ---
 


### PR DESCRIPTION
## Summary

- **New:** `rke2-reference/README.md` — quick reference for RKE2/k3s: install, binary locations, kubeconfig, containerd, ctr, crictl, logging, systemd service files, distribution contents
- **Rewrite:** `etcd/README.md` — full command suite via `kubectl exec` and `crictl exec`; port 2381 for metrics/health; compact, defrag, watch, key queries; deprecated RKE1 section preserved
- **Rewrite:** `etcd/check-endpoints.sh` — auto-detects RKE2/k3s, runs health/status/members/alarms via `crictl exec`
- **Rewrite:** `kube-apiserver/check_apiserver-to-etcd.sh` — RKE2/k3s cert paths, crictl-based
- **Rewrite:** `kube-scheduler/find-leader.sh` — Lease-based leader election (replaces deprecated Endpoints annotation)
- **Fix:** `kube-apiserver/check_endpoints.sh` — `controlplane` → `control-plane` node-role label
- **Fix:** `kube-apiserver/responsiveness.sh` — same label fix
- **Update:** `determine-leader/rancher2_determine_leader.sh` — empty-check guard, jsonpath directly
- **Rewrite:** `troubleshooting-scripts/README.md` — updated table of contents

## Key corrections vs prior scripts (tested on RKE2 v1.33.7)

| Issue | Old | Fixed |
|-------|-----|-------|
| etcdctl on host | `/var/lib/rancher/rke2/bin/etcdctl` (not present v1.31+) | `crictl exec <id> etcdctl` |
| etcd metrics/health | `curl https://127.0.0.1:2379/...` (gRPC port, no curl) | `curl http://127.0.0.1:2381/...` |
| Node-role label | `controlplane=true` (RKE1) | `control-plane=true` |
| Scheduler leader | Endpoints annotation (removed) | `kube-system/kube-scheduler` Lease |

## Test plan

- [ ] `bash -n` syntax check passes on all `.sh` files
- [ ] Verify `etcd/check-endpoints.sh` on an RKE2 v1.31+ server node
- [ ] Confirm `kube-apiserver/check_endpoints.sh` returns nodes (control-plane label fix)
- [ ] Confirm `kube-scheduler/find-leader.sh` returns a node name