### PR TITLE
fix: replace curl|bash with download+sha256+run for supply chain compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 .DS_Store
 **/scc-support-bundle-*
+
+# AI agent files
+CLAUDE.md
+.claude/
+.cursor/
+.cursorrules
+.copilot/
+.github/copilot-instructions.md
+.aider*
+.continue/

--- a/NGINX-to-pods-check/README.md
+++ b/NGINX-to-pods-check/README.md
@@ -3,7 +3,10 @@ This script is designed to walk through all the ingresses in a cluster and test 
 
 ## Run script
 ```
-curl https://raw.githubusercontent.com/rancherlabs/support-tools/master/NGINX-to-pods-check/check.sh | bash
+curl -sL https://raw.githubusercontent.com/rancherlabs/support-tools/master/NGINX-to-pods-check/check.sh -o /tmp/check.sh
+# sha256 as of master — update this hash after modifying the script
+echo "e263fc245aa50475440f4e45870168da6cb8a0c59fcafc9f022dd0cb9aef691a  /tmp/check.sh" | sha256sum -c -
+bash /tmp/check.sh
 ```
 
 ## Example output

--- a/collection/rancher/v2.x/logs-collector/README.md
+++ b/collection/rancher/v2.x/logs-collector/README.md
@@ -35,7 +35,10 @@ Output will be written to `/tmp` as a tar.gz archive named `<hostname>-<date>.ta
 
 ### Optional: Download and run the script in one command
   ```bash
-  curl -Ls rnch.io/rancher2_logs | sudo bash
+  curl -sL https://rnch.io/rancher2_logs -o /tmp/rancher2_logs_collector.sh
+  # sha256 as of master — update this hash after modifying the script
+  echo "c3a29113c74149da2232ca3510a373d3ac7e225d04ef5ebf12371e2f9fe5e6ac  /tmp/rancher2_logs_collector.sh" | sha256sum -c -
+  sudo bash /tmp/rancher2_logs_collector.sh
   ```
   > Note: This command requires `curl` to be installed, and internet access from the node.
 

--- a/swiss-army-knife/README.md
+++ b/swiss-army-knife/README.md
@@ -25,7 +25,10 @@ This will deploy a deamonset that will run on all nodes in the cluster. These po
 
 You can run the overlay test script by running the following command:
 ```bash
-curl -sfL https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/overlaytest.sh | bash
+curl -sL https://raw.githubusercontent.com/rancherlabs/support-tools/master/swiss-army-knife/overlaytest.sh -o /tmp/overlaytest.sh
+# sha256 as of master — update this hash after modifying the script
+echo "02b00cd7c301229e8eece46a10119db187b520e4e0fd17955fb4e4b153dbe3dd  /tmp/overlaytest.sh" | sha256sum -c -
+bash /tmp/overlaytest.sh
 ```
 
 ### Admin Tools


### PR DESCRIPTION
## Summary

Replace `curl ... | bash` / `curl ... | sh` patterns with a secure three-step pattern across three README files:

1. Download the script to a temp file
2. Validate `sha256` checksum before execution  
3. Run the verified local script

## Motivation

Follows the Rancher Security Team standard for supply chain risk mitigation (section 3.4 and 3.5 of the supply chain scan guidance): scripts piped directly from curl to bash cannot be verified before execution — if a dependency is compromised, the malicious payload runs immediately.

## Files changed

| File | Change |
|------|--------|
| `NGINX-to-pods-check/README.md` | Replace `curl .../check.sh \| bash` with download+sha256+run |
| `swiss-army-knife/README.md` | Replace `curl .../overlaytest.sh \| bash` with download+sha256+run |
| `collection/rancher/v2.x/logs-collector/README.md` | Replace `curl -Ls rnch.io/rancher2_logs \| sudo bash` with download+sha256+run |
| `.gitignore` | Add AI agent config files |

## Note on checksums

The sha256 hashes are computed against the scripts at the time of this PR. Each comment references the source branch (`master`). **Update the hash when modifying the referenced script.**

## Related

- Companion PR fixing `troubleshooting-scripts/`: rancherlabs/support-tools#434
- Rancher Security Team supply chain scan guidance: https://github.com/rancher/security-team/wiki/supply-chain-scans/how-to-act