### PR TITLE
Adding detect-secrets to pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  detect_secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install detect-secrets
+        run: pip install detect-secrets
+
+      - name: Build baseline from origin/master
+        run: |
+          git fetch origin master
+          git worktree add /tmp/main-checkout origin/master
+          # Copy baseline config so detect-secrets uses consistent plugins/filters
+          cp .secrets.baseline /tmp/main-checkout/
+          cd /tmp/main-checkout
+          detect-secrets scan \
+            --exclude-files '\.secrets\.baseline' \
+            . > /tmp/main-baseline.json
+          cd $GITHUB_WORKSPACE
+          rm -rf /tmp/main-checkout
+          git worktree prune
+
+      - name: Scan merge commit and compare
+        run: |
+          detect-secrets scan \
+            --exclude-files '\.secrets\.baseline' \
+            > /tmp/pr-scan.json
+          python3 - <<'EOF'
+          import json, sys
+
+          with open('/tmp/pr-scan.json') as f:
+              pr_scan = json.load(f)
+          with open('/tmp/main-baseline.json') as f:
+              main_baseline = json.load(f)
+
+          # Hashes from origin/master's current code
+          main_hashes = {
+              s['hashed_secret']
+              for secrets in main_baseline.get('results', {}).values()
+              for s in secrets
+          }
+
+          # Hashes from the committed baseline — covers legacy reviewed findings
+          # that master may have since diverged from, or the first-time setup
+          try:
+              with open('.secrets.baseline') as f:
+                  committed = json.load(f)
+              committed_hashes = {
+                  s['hashed_secret']
+                  for secrets in committed.get('results', {}).values()
+                  for s in secrets
+              }
+          except (FileNotFoundError, json.JSONDecodeError):
+              committed_hashes = set()
+
+          # Union: known-safe set covers both current master + legacy reviewed state
+          baseline_hashes = main_hashes | committed_hashes
+
+          new_findings = []
+          for path, secrets in pr_scan.get('results', {}).items():
+              for s in secrets:
+                  if s['hashed_secret'] not in baseline_hashes:
+                      new_findings.append((path, s))
+
+          if new_findings:
+              print("UNREVIEWED SECRETS introduced by this PR:")
+              for path, s in sorted(new_findings, key=lambda x: (x[0], x[1].get('line_number', 0))):
+                  print(f"  {path}:{s['line_number']} [{s['type']}]")
+              sys.exit(1)
+
+          pr_total = sum(len(v) for v in pr_scan.get('results', {}).values())
+          print(f"All {pr_total} finding(s) are in the baseline — OK")
+          EOF

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,195 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.secrets\\.baseline"
+      ]
+    }
+  ],
+  "results": {
+    "bad-ingress-scanner/bad-ingress.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "bad-ingress-scanner/bad-ingress.yaml",
+        "hashed_secret": "77be3fa7d30ef68a10e36fdc51b9e607086b57b5",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "charts/index.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "charts/index.yaml",
+        "hashed_secret": "0ff01e80b7b48c6421de25d1d107f1ba95cf4fd2",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "charts/systems-info/values.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "charts/systems-info/values.yaml",
+        "hashed_secret": "208100f1cdc4c5c7727dc565fb8aa826df8b00c8",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "charts/systems-information/values.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "charts/systems-information/values.yaml",
+        "hashed_secret": "208100f1cdc4c5c7727dc565fb8aa826df8b00c8",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "collection/rancher/v2.x/scc-operator-collector/analyzer.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "collection/rancher/v2.x/scc-operator-collector/analyzer.sh",
+        "hashed_secret": "ba415e0f7feaabaf8555e4bd0728b7aa4ea3a57b",
+        "is_verified": false,
+        "line_number": 96
+      }
+    ],
+    "collection/rancher/v2.x/scc-operator-collector/scc-operator-collector.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "collection/rancher/v2.x/scc-operator-collector/scc-operator-collector.sh",
+        "hashed_secret": "f872bba4c6451b35cc87b019aeee01683ea7a1a1",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "collection/rancher/v2.x/scc-operator-collector/scc-operator-collector.sh",
+        "hashed_secret": "ba415e0f7feaabaf8555e4bd0728b7aa4ea3a57b",
+        "is_verified": false,
+        "line_number": 151
+      }
+    ]
+  },
+  "generated_at": "2026-05-11T23:18:59Z"
+}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -129,6 +129,15 @@
     }
   ],
   "results": {
+    ".github/workflows/ci.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yaml",
+        "hashed_secret": "99e16bf2a997899c867f03326425afd117d43fc5",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
     "bad-ingress-scanner/bad-ingress.yaml": [
       {
         "type": "Secret Keyword",
@@ -191,5 +200,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-11T23:18:59Z"
+  "generated_at": "2026-05-11T23:34:24Z"
 }


### PR DESCRIPTION
- Adds detect_secrets job to actions, fails of any new secret is committed that isn't in the baseline
- Adding initial baseline

A new baseline can be built with the below, if failures are detected in a PR:
```bash
detect-secrets scan \
  --exclude-files '\.secrets\.baseline' \
  > .secrets.baseline
```