### PR TITLE
Add calico network policies

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -17,7 +17,7 @@ VAR_LOG_FILES=(syslog messages kern docker cloud-init audit/ dmesg)
 
 # Included Kubernetes object types
 K8S_OBJECTS=(clusterroles clusterrolebindings crds mutatingwebhookconfigurations namespaces nodes pv validatingwebhookconfigurations volumeattachments)
-K8S_OBJECTS_NAMESPACED=(apiservices configmaps cronjobs deployments daemonsets endpoints events helmcharts hpa ingress jobs leases networkpolicies pods pvc replicasets roles rolebindings statefulsets)
+K8S_OBJECTS_NAMESPACED=(apiservices configmaps cronjobs deployments daemonsets endpoints events helmcharts hpa ingress jobs leases networkpolicies networkpolicies.projectcalico.org globalnetworkpolicies.projectcalico.org pods pvc replicasets roles rolebindings statefulsets)
 
 # Default days log files to include
 DEFAULT_LOG_DAYS=7


### PR DESCRIPTION
Resolves: https://github.com/rancherlabs/support-tools/issues/449

Tested on RKE2 with:
```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-calico
  namespace: kube-system
spec:
  valuesContent: |-
    manageCRDs: true
    apiServer:
      enabled: true
```

```bash
.../rke2/kubectl# cat networkpolicies.projectcalico.org
NAMESPACE       NAME                                   CREATED AT
calico-system   calico-system.apiserver-access         2026-05-26T22:27:10Z
calico-system   calico-system.default-deny             2026-05-26T22:20:43Z
calico-system   calico-system.kube-controller-access   2026-05-26T22:20:43Z
default         allow-tcp-6379                         2026-05-26T22:35:44Z
kube-system     calico-system.cluster-dns              2026-05-26T22:20:38Z

...rke2/kubectl# cat globalnetworkpolicies.projectcalico.org
NAME                           CREATED AT
calico-system.node-local-dns   2026-05-26T22:20:39Z
```