### PR TITLE
Add since flag for journalctl collection

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -262,7 +262,7 @@ system-all() {
   if command -v systemctl >/dev/null 2>&1; then
     systemctl list-unit-files > "${TMPDIR}/systeminfo/systemd-unit-files" 2>&1
   fi
-  if command -v systemd-detect-virt 2>&1; then
+  if command -v systemd-detect-virt >/dev/null 2>&1; then
     systemd-detect-virt > "${TMPDIR}/systeminfo/systemd-detect-virt" 2>&1
   fi
   if command -v service >/dev/null 2>&1; then
@@ -926,6 +926,11 @@ var-log() {
 
 journald-log() {
 
+  if [ -n "${START_DAY}" ]
+    then
+      DEFAULT_LOG_DAYS="$START_DAY"
+  fi
+
   JOURNALCTL_CMD=(journalctl)
   [ -n "${SINCE_FLAG[*]}" ] && JOURNALCTL_CMD+=("${SINCE_FLAG[@]}")
   [ -n "${UNTIL_FLAG[*]}" ] && JOURNALCTL_CMD+=("${UNTIL_FLAG[@]}")
@@ -934,7 +939,7 @@ journald-log() {
   mkdir -p "${TMPDIR}/journald"
   for JOURNALD_LOG in "${JOURNALD_LOGS[@]}"; do
     if grep "$JOURNALD_LOG.service" "${TMPDIR}/systeminfo/systemd-unit-files" > /dev/null 2>&1; then
-      "${JOURNALCTL_CMD[@]}" --unit="$JOURNALD_LOG" > "${TMPDIR}/journald/$JOURNALD_LOG"
+      "${JOURNALCTL_CMD[@]}" --unit="$JOURNALD_LOG" --since "${DEFAULT_LOG_DAYS} days ago" > "${TMPDIR}/journald/$JOURNALD_LOG"
     fi
   done
 


### PR DESCRIPTION
Tested on RKE2 with `-s 1` which collected 1 day of log entries, example:

```bash
.../journald# head rke2-server -n 2
-- Logs begin at Wed 2025-02-05 12:35:47 UTC, end at Thu 2026-05-28 04:32:55 UTC. --
May 27 04:33:13 ip-10-99-12-180 rke2[3118787]: time="2026-05-27T04:33:13Z" level=info msg="Reconciling ETCDSnapshotFile resources"

.../journald# tail rke2-server -n 1
May 28 04:24:15 ip-10-99-12-180 rke2[3118787]: time="2026-05-28T04:24:15Z" level=info msg="Reconciliation of ETCDSnapshotFile resources complete"
```

Also added `>/dev/null` for `detect-virt` as this is being output unintentionally.