### PR TITLE
Add Prometheus alerting rules for etcd monitoring

### DIFF
--- a/etcd-monitor/README.md
+++ b/etcd-monitor/README.md
@@ -1,0 +1,24 @@
+# etcd-monitor
+Monitor RKE2 exposed etcd metrics to increase Cluster stability
+
+etcd already exposes Prometheus metrics for member health, DB size, disk fsync latency, and leader changes. RKE2 also documents metrics support for cluster components, including etcd.   
+The rules in this repo can be used to monitor etcd and alerts when treshold is reached.
+
+## What it monitors
+
+- etcd member availability
+- etcd leader presence
+- leader election frequency
+- database size and growth rate
+- WAL fsync latency
+- backend commit latency
+- apply/request latency
+- etcd quota usage
+- member count and quorum risk
+
+## How to use it
+Download the etcd-monitor.yaml and apply it to your cluster
+
+kubectl apply -f etcd-monitor.yaml
+
+

--- a/etcd-monitor/README.md
+++ b/etcd-monitor/README.md
@@ -2,7 +2,7 @@
 Monitor RKE2 exposed etcd metrics to increase Cluster stability
 
 etcd already exposes Prometheus metrics for member health, DB size, disk fsync latency, and leader changes. RKE2 also documents metrics support for cluster components, including etcd.   
-The rules in this repo can be used to monitor etcd and alerts when treshold is reached.
+The rules in this repo can be used to monitor etcd and alert when the threshold is reached. They are designed to integrate seamlessly with the rancher-monitoring stack.
 
 ## What it monitors
 

--- a/etcd-monitor/README.md
+++ b/etcd-monitor/README.md
@@ -2,6 +2,7 @@
 Monitor RKE2 exposed etcd metrics to increase Cluster stability
 
 etcd already exposes Prometheus metrics for member health, DB size, disk fsync latency, and leader changes. RKE2 also documents metrics support for cluster components, including etcd.   
+
 The rules in this repo can be used to monitor etcd and alert when the threshold is reached. They are designed to integrate seamlessly with the rancher-monitoring stack.
 
 ## What it monitors
@@ -20,11 +21,11 @@ The rules in this repo can be used to monitor etcd and alert when the threshold 
 Download the either the `etcd-monitor.yaml` or `etcd-monitor-extended.yaml` and apply it to the cluster
 
 **Option 1: Standard Monitoring (Recommended)**
+
 Provides essential coverage for quorum loss, leader elections, high disk latency, and quota exhaustion.
 - `kubectl apply -f etcd-monitor.yaml`
+
 **Option 2: Extended Monitoring**
+
 Includes the standard alerts plus deeper insights into apply latencies, read index slowness, and proposal backlogs (useful for high-load clusters).
 - `kubectl apply -f etcd-monitor-extended.yaml`
-
-
-

--- a/etcd-monitor/README.md
+++ b/etcd-monitor/README.md
@@ -26,6 +26,5 @@ Provides essential coverage for quorum loss, leader elections, high disk latency
 Includes the standard alerts plus deeper insights into apply latencies, read index slowness, and proposal backlogs (useful for high-load clusters).
 - `kubectl apply -f etcd-monitor-extended.yaml`
 
-kubectl apply -f etcd-monitor.yaml
 
 

--- a/etcd-monitor/README.md
+++ b/etcd-monitor/README.md
@@ -17,7 +17,14 @@ The rules in this repo can be used to monitor etcd and alert when the threshold 
 - member count and quorum risk
 
 ## How to use it
-Download the etcd-monitor.yaml and apply it to your cluster
+Download the either the `etcd-monitor.yaml` or `etcd-monitor-extended.yaml` and apply it to the cluster
+
+**Option 1: Standard Monitoring (Recommended)**
+Provides essential coverage for quorum loss, leader elections, high disk latency, and quota exhaustion.
+- `kubectl apply -f etcd-monitor.yaml`
+**Option 2: Extended Monitoring**
+Includes the standard alerts plus deeper insights into apply latencies, read index slowness, and proposal backlogs (useful for high-load clusters).
+- `kubectl apply -f etcd-monitor-extended.yaml`
 
 kubectl apply -f etcd-monitor.yaml
 

--- a/etcd-monitor/etcd-monitor-extended.yaml
+++ b/etcd-monitor/etcd-monitor-extended.yaml
@@ -1,0 +1,212 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rke2-etcd-quorum-early-warning
+  namespace: cattle-monitoring-system
+  labels:
+    release: rancher-monitoring
+spec:
+  groups:
+    - name: rke2-etcd-quorum-early-warning
+      rules:
+        - alert: EtcdMemberDown
+          expr: up{job=~".*etcd.*"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd member is not reachable"
+            description: "Prometheus cannot scrape etcd metrics from {{ $labels.instance }} for more than 2 minutes."
+
+        - alert: EtcdNoLeader
+          expr: etcd_server_has_leader == 0
+          for: 1m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd member reports no leader"
+            description: "etcd member {{ $labels.instance }} has no leader. API instability or quorum loss may follow."
+
+        - alert: EtcdFrequentLeaderChanges
+          expr: increase(etcd_server_leader_changes_seen_total[15m]) > 3
+          for: 5m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "Frequent etcd leader changes detected"
+            description: "etcd has seen more than 3 leader changes in 15 minutes. This may indicate network, disk, CPU, or member health issues."
+
+        - alert: EtcdHighWALFsyncLatency
+          expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "High etcd WAL fsync latency"
+            description: "p99 WAL fsync latency is above 500ms on {{ $labels.instance }}. This often points to disk latency or I/O starvation."
+
+        - alert: EtcdHighBackendCommitLatency
+          expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "High etcd backend commit latency"
+            description: "p99 backend commit latency is above 500ms on {{ $labels.instance }}."
+
+        - alert: EtcdDatabaseSizeGrowingQuickly
+          expr: increase(etcd_mvcc_db_total_size_in_bytes[1h]) > 1073741824
+          for: 15m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd database size is growing quickly"
+            description: "etcd DB on {{ $labels.instance }} grew by more than 1GiB in the last hour."
+
+        - alert: EtcdDatabaseQuotaNearLimit
+          expr: etcd_mvcc_db_total_size_in_use_in_bytes / etcd_server_quota_backend_bytes > 0.8
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd database quota usage is above 80%"
+            description: "etcd backend quota usage is above 80% on {{ $labels.instance }}."
+
+        - alert: EtcdDatabaseQuotaCritical
+          expr: etcd_mvcc_db_total_size_in_use_in_bytes / etcd_server_quota_backend_bytes > 0.95
+          for: 5m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd database quota usage is critical"
+            description: "etcd backend quota usage is above 95% on {{ $labels.instance }}. NOSPACE alarms or write failures may occur soon."
+
+        - alert: EtcdHighApplyLatency
+          expr: histogram_quantile(0.99, rate(etcd_server_apply_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "High etcd apply latency"
+            description: "p99 etcd apply latency is above 500ms on {{ $labels.instance }}."
+
+        - alert: EtcdInsufficientMembersVisible
+          expr: count(up{job=~".*etcd.*"} == 1) < 3
+          for: 2m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "Fewer than 3 etcd members are visible"
+            description: "Prometheus sees fewer than 3 healthy etcd scrape targets. Validate etcd quorum immediately."
+
+    - name: etcd.latency.rules
+      rules:
+        - alert: EtcdApplyLatencyHigh
+          expr: histogram_quantile(0.99, rate(etcd_server_apply_duration_seconds_bucket[5m])) > 1
+          for: 5m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd apply latency is high"
+            description: "p99 etcd apply latency exceeds 1 second on {{ $labels.instance }}."
+
+        - alert: EtcdApplyLatencyCritical
+          expr: histogram_quantile(0.99, rate(etcd_server_apply_duration_seconds_bucket[5m])) > 5
+          for: 3m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd apply latency is critical"
+            description: "p99 etcd apply latency exceeds 5 seconds on {{ $labels.instance }}. This can indicate etcd requests are stalling even when quorum is healthy."
+
+        - alert: EtcdApplyLatencyExtreme
+          expr: histogram_quantile(0.99, rate(etcd_server_apply_duration_seconds_bucket[5m])) > 10
+          for: 1m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd apply latency is extreme"
+            description: "p99 etcd apply latency exceeds 10 seconds on {{ $labels.instance }}. This mirrors 'apply request took too long' events seen during Rancher/API slowness."
+
+        - alert: EtcdSlowApplyEventsIncreasing
+          expr: increase(etcd_server_slow_apply_total[5m]) > 0
+          for: 2m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd slow apply operations detected"
+            description: "etcd is reporting slow apply operations on {{ $labels.instance }}."
+
+        - alert: EtcdSlowReadEventsIncreasing
+          expr: increase(etcd_server_slow_read_indexes_total[5m]) > 0
+          for: 2m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd slow read operations detected"
+            description: "etcd is reporting slow read index operations on {{ $labels.instance }}."
+
+        - alert: EtcdProposalApplyBacklog
+          expr: etcd_server_proposals_committed_total - etcd_server_proposals_applied_total > 500
+          for: 5m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd proposal apply backlog detected"
+            description: "Committed proposals are ahead of applied proposals by more than 500 on {{ $labels.instance }}."
+
+        - alert: EtcdProposalApplyBacklogCritical
+          expr: etcd_server_proposals_committed_total - etcd_server_proposals_applied_total > 5000
+          for: 3m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "critical etcd proposal apply backlog"
+            description: "Committed proposals are ahead of applied proposals by more than 5000 on {{ $labels.instance }}."
+
+        - alert: EtcdPendingProposalsHigh
+          expr: etcd_server_proposals_pending > 100
+          for: 5m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd pending proposals are elevated"
+            description: "Pending proposals exceed 100 on {{ $labels.instance }}."
+
+        - alert: EtcdPendingProposalsCritical
+          expr: etcd_server_proposals_pending > 1000
+          for: 2m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd pending proposals are critical"
+            description: "Pending proposals exceed 1000 on {{ $labels.instance }}."
+
+        - alert: EtcdProposalFailuresIncreasing
+          expr: increase(etcd_server_proposals_failed_total[5m]) > 0
+          for: 2m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd proposal failures detected"
+            description: "Failed etcd proposal count is increasing on {{ $labels.instance }}."

--- a/etcd-monitor/etcd-monitor.yaml
+++ b/etcd-monitor/etcd-monitor.yaml
@@ -1,0 +1,110 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rke2-etcd-quorum-early-warning
+  namespace: cattle-monitoring-system
+  labels:
+    release: rancher-monitoring
+spec:
+  groups:
+    - name: rke2-etcd-quorum-early-warning
+      rules:
+        - alert: EtcdMemberDown
+          expr: up{job=~".*etcd.*"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd member is not reachable"
+            description: "Prometheus cannot scrape etcd metrics from {{ $labels.instance }} for more than 2 minutes."
+
+        - alert: EtcdNoLeader
+          expr: etcd_server_has_leader == 0
+          for: 1m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd member reports no leader"
+            description: "etcd member {{ $labels.instance }} has no leader. API instability or quorum loss may follow."
+
+        - alert: EtcdFrequentLeaderChanges
+          expr: increase(etcd_server_leader_changes_seen_total[15m]) > 3
+          for: 5m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "Frequent etcd leader changes detected"
+            description: "etcd has seen more than 3 leader changes in 15 minutes. This may indicate network, disk, CPU, or member health issues."
+
+        - alert: EtcdHighWALFsyncLatency
+          expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "High etcd WAL fsync latency"
+            description: "p99 WAL fsync latency is above 500ms on {{ $labels.instance }}. This often points to disk latency or I/O starvation."
+
+        - alert: EtcdHighBackendCommitLatency
+          expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "High etcd backend commit latency"
+            description: "p99 backend commit latency is above 500ms on {{ $labels.instance }}."
+
+        - alert: EtcdDatabaseSizeGrowingQuickly
+          expr: increase(etcd_mvcc_db_total_size_in_bytes[1h]) > 1073741824
+          for: 15m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd database size is growing quickly"
+            description: "etcd DB on {{ $labels.instance }} grew by more than 1GiB in the last hour."
+
+        - alert: EtcdDatabaseQuotaNearLimit
+          expr: etcd_mvcc_db_total_size_in_use_in_bytes / etcd_server_quota_backend_bytes > 0.8
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "etcd database quota usage is above 80%"
+            description: "etcd backend quota usage is above 80% on {{ $labels.instance }}."
+
+        - alert: EtcdDatabaseQuotaCritical
+          expr: etcd_mvcc_db_total_size_in_use_in_bytes / etcd_server_quota_backend_bytes > 0.95
+          for: 5m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "etcd database quota usage is critical"
+            description: "etcd backend quota usage is above 95% on {{ $labels.instance }}. NOSPACE alarms or write failures may occur soon."
+
+        - alert: EtcdHighApplyLatency
+          expr: histogram_quantile(0.99, rate(etcd_server_apply_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            category: etcd
+          annotations:
+            summary: "High etcd apply latency"
+            description: "p99 etcd apply latency is above 500ms on {{ $labels.instance }}."
+
+        - alert: EtcdInsufficientMembersVisible
+          expr: count(up{job=~".*etcd.*"} == 1) < 3
+          for: 2m
+          labels:
+            severity: critical
+            category: etcd
+          annotations:
+            summary: "Fewer than 3 etcd members are visible"
+            description: "Prometheus sees fewer than 3 healthy etcd scrape targets. Validate etcd quorum immediately."


### PR DESCRIPTION
This file defines Prometheus alerting rules for monitoring etcd health, including alerts for member status, leader presence, latency issues, and database size thresholds.
