### PR TITLE
Add shellcheck, include detect-secrets in PR comments

### DIFF
--- a/.github/workflows/broken-script-test.sh
+++ b/.github/workflows/broken-script-test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+Echo "testing 123"
+
+var=$12
+
+if [[ $1 = '1' ]] then
+ Echo broken
+if

--- a/.github/workflows/broken-script-test.sh
+++ b/.github/workflows/broken-script-test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-Echo "testing 123"
-
-var=$12
-
-if [[ $1 = '1' ]] then
- Echo broken
-if

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,11 @@ on:
 jobs:
   detect_secrets:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install detect-secrets
         run: pip install detect-secrets
@@ -76,10 +78,40 @@ jobs:
 
           if new_findings:
               print("UNREVIEWED SECRETS introduced by this PR:")
-              for path, s in sorted(new_findings, key=lambda x: (x[0], x[1].get('line_number', 0))):
-                  print(f"  {path}:{s['line_number']} [{s['type']}]")
+              with open('/tmp/secrets_report.md', 'w') as out:
+                  out.write("### 🚨 Unreviewed Secrets Detected\n\n")
+                  out.write("The following secrets were introduced in this PR and are not present in the `.secrets.baseline` file:\n\n")
+                  out.write("| File Path | Line | Secret Type |\n")
+                  out.write("|---|---|---|\n")
+                  for path, s in sorted(new_findings, key=lambda x: (x[0], x[1].get('line_number', 0))):
+                      print(f"  {path}:{s['line_number']} [{s['type']}]")
+                      out.write(f"| `{path}` | `{s['line_number']}` | {s['type']} |\n")
               sys.exit(1)
 
           pr_total = sum(len(v) for v in pr_scan.get('results', {}).values())
           print(f"All {pr_total} finding(s) are in the baseline — OK")
           EOF
+
+      - name: Comment PR on Failure
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f /tmp/secrets_report.md ]; then
+            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/secrets_report.md
+          fi
+
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          level: warning
+          check_all_files_with_shebangs: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install detect-secrets
         run: pip install detect-secrets
@@ -107,7 +107,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Run shellcheck and annotate PR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,11 +108,31 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
       - name: Run shellcheck and annotate PR
         run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            git fetch origin ${{ github.event.pull_request.base.ref }}
+            BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+          else
+            BASE_REF="HEAD^"
+          fi
+
+          # Get list of added/modified .sh files
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR $BASE_REF...HEAD | grep '\.sh$' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No shell scripts changed. Skipping shellcheck."
+            exit 0
+          fi
+
+          echo "Running shellcheck on the following files:"
+          echo "$CHANGED_FILES"
+
           # Use jq to parse the JSON output of shellcheck and translate it into native GitHub Actions annotations
           # This automatically highlights warnings/errors directly inline on the PR code tab
-          shellcheck -f json $(find . -type f -name "*.sh") | jq -r '.[] | "::\(if .level == "error" then "error" elif .level == "warning" then "warning" else "notice" end) file=\(.file),line=\(.line),col=\(.column),title=ShellCheck \(.code)::\(.message)"'
+          echo "$CHANGED_FILES" | xargs shellcheck -f json | jq -r '.[] | "::\(if .level == "error" then "error" elif .level == "warning" then "warning" else "notice" end) file=\(.file),line=\(.line),col=\(.column),title=ShellCheck \(.code)::\(.message)"'
           
           # Rerun normally to print the human-readable output and fail the job if errors exist
-          shellcheck $(find . -type f -name "*.sh")
+          echo "$CHANGED_FILES" | xargs shellcheck

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,16 +102,17 @@ jobs:
           fi
 
   shellcheck:
-    name: runner / shellcheck
+    name: shellcheck
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - name: shellcheck
-        uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-          level: warning
-          check_all_files_with_shebangs: "true"
+      - name: Run shellcheck and annotate PR
+        run: |
+          # Use jq to parse the JSON output of shellcheck and translate it into native GitHub Actions annotations
+          # This automatically highlights warnings/errors directly inline on the PR code tab
+          shellcheck -f json $(find . -type f -name "*.sh") | jq -r '.[] | "::\(if .level == "error" then "error" elif .level == "warning" then "warning" else "notice" end) file=\(.file),line=\(.line),col=\(.column),title=ShellCheck \(.code)::\(.message)"'
+          
+          # Rerun normally to print the human-readable output and fail the job if errors exist
+          shellcheck $(find . -type f -name "*.sh")


### PR DESCRIPTION
Resolves: https://github.com/rancherlabs/support-tools/pull/371

- Add shellcheck into GHA, include comment on PR if warning level detected
- Increase pinned version checksums
- Add detect-secrets comment on PR if failure detected